### PR TITLE
Cere fixes part 10

### DIFF
--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -159,6 +159,7 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "aba" = (
@@ -214,7 +215,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "abi" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/item/storage/backpack/duffelbag/sec/surgery{
@@ -229,14 +230,14 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "abk" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "abl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -368,7 +369,7 @@
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "abx" = (
 /obj/structure/showcase{
 	density = 0;
@@ -450,7 +451,7 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "abF" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plating/asteroid,
@@ -460,13 +461,13 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "abH" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/breath,
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "abI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -527,13 +528,15 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "abX" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "abY" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/plating/asteroid,
@@ -673,6 +676,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "acD" = (
@@ -691,8 +695,9 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "acJ" = (
 /obj/machinery/holopad,
 /turf/open/floor/circuit,
@@ -782,7 +787,7 @@
 "adn" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plating,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "ado" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/telecomms,
@@ -992,16 +997,9 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
 "aeD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/security/brig/upper)
+/area/maintenance/external/aft)
 "aeF" = (
 /obj/structure/table,
 /obj/item/cultivator,
@@ -1088,7 +1086,6 @@
 /area/tcommsat/server)
 "afp" = (
 /obj/machinery/door/airlock/engineering/glass{
-	cyclelinkeddir = 4;
 	name = "Server Room";
 	req_access_txt = "61"
 	},
@@ -1124,7 +1121,6 @@
 /area/tcommsat/computer)
 "afr" = (
 /obj/machinery/door/airlock/engineering/glass{
-	cyclelinkeddir = 8;
 	name = "Server Room";
 	req_access_txt = "61"
 	},
@@ -1235,12 +1231,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afS" = (
-/obj/machinery/turretid{
-	name = "AI Chamber turret control";
-	pixel_y = 24
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "afT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -1254,6 +1250,7 @@
 	icon_state = "plant-09"
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afW" = (
@@ -1327,7 +1324,7 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "agH" = (
-/obj/machinery/telecomms/message_server,
+/obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/circuit/telecomms,
 /area/tcommsat/server)
 "agI" = (
@@ -1411,6 +1408,7 @@
 /obj/item/radio,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "agT" = (
@@ -1418,6 +1416,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "agU" = (
@@ -1511,6 +1510,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"ahp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/grimy,
+/area/maintenance/fore/greater)
 "ahv" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/circuit/telecomms,
@@ -1826,6 +1832,7 @@
 /area/security/brig/upper)
 "ajf" = (
 /obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/external/aft)
 "ajg" = (
@@ -1903,27 +1910,27 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "ajE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "ajF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "ajG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "ajH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2107,8 +2114,9 @@
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain)
 "ako" = (
-/turf/closed/wall,
-/area/ai_monitored/turret_protected/aisat/maint)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "akp" = (
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/hallway)
@@ -2122,9 +2130,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "akr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2136,9 +2143,8 @@
 	name = "External Airlock Access";
 	req_access_txt = "12"
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "aks" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2191,7 +2197,7 @@
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "akw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
@@ -2203,7 +2209,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "akx" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -2355,6 +2361,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
 "ala" = (
@@ -2369,7 +2376,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "alc" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -2526,7 +2533,7 @@
 "alJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "alK" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -2766,7 +2773,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "amo" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -2840,12 +2847,14 @@
 /turf/open/space,
 /area/space)
 "amD" = (
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "amE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "amF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/west{
@@ -3078,13 +3087,11 @@
 /turf/open/space,
 /area/space)
 "ano" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "anp" = (
 /obj/machinery/status_display/ai{
 	pixel_x = 32
@@ -3093,13 +3100,11 @@
 /turf/open/floor/iron,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "anq" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "anr" = (
 /obj/effect/turf_decal/stripes/asteroid/end,
 /obj/effect/turf_decal/sand/plating,
@@ -3251,6 +3256,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
 "anV" = (
@@ -3407,13 +3413,13 @@
 /obj/machinery/light/small/directional/east,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "aoq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/west,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "aor" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/asteroid,
@@ -3455,6 +3461,7 @@
 /obj/machinery/status_display/supply{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "aox" = (
@@ -3510,6 +3517,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "aoG" = (
@@ -3570,23 +3578,9 @@
 /turf/closed/wall,
 /area/commons/dorms/barracks/female)
 "aoW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/engine,
+/area/hallway/primary/central)
 "aoY" = (
 /obj/structure/dresser,
 /obj/structure/cable,
@@ -3660,15 +3654,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "apk" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "apl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
@@ -3696,15 +3688,13 @@
 /turf/open/floor/iron,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "apn" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "apq" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -4167,7 +4157,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -4220,7 +4209,7 @@
 	network = list("SS13")
 	},
 /turf/open/floor/engine,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "aqX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4243,6 +4232,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ara" = (
@@ -4311,7 +4301,6 @@
 /area/cargo/storage)
 "arg" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 8;
 	name = "Supply Dock Airlock";
 	req_access_txt = "31"
 	},
@@ -4396,7 +4385,7 @@
 "arx" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "ary" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Dorm Commons North"
@@ -4404,6 +4393,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/locker)
 "arz" = (
@@ -4528,7 +4518,6 @@
 /area/command/bridge)
 "arQ" = (
 /obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4;
 	name = "Command Escape Pod"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -4537,10 +4526,12 @@
 "arR" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
 "arT" = (
 /obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/cargo/warehouse)
 "arU" = (
@@ -4552,6 +4543,7 @@
 /area/cargo/warehouse)
 "arV" = (
 /obj/item/radio/intercom/directional/west,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "arW" = (
@@ -4559,7 +4551,6 @@
 /area/maintenance/department/cargo)
 "asa" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 4;
 	name = "Supply Dock Airlock";
 	req_access_txt = "31"
 	},
@@ -4727,6 +4718,11 @@
 /obj/item/storage/secure/safe/directional/west,
 /turf/open/floor/carpet,
 /area/command/bridge)
+"asF" = (
+/obj/structure/table,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "asI" = (
 /turf/closed/wall/rust,
 /area/maintenance/fore/greater)
@@ -4800,6 +4796,7 @@
 /area/cargo/warehouse)
 "asW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/cargo/warehouse)
 "asX" = (
@@ -5008,6 +5005,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/locker)
 "atB" = (
@@ -5165,12 +5163,10 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "atS" = (
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/external/aft)
 "atT" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -5192,6 +5188,7 @@
 "atY" = (
 /obj/effect/spawner/random/structure/crate_empty,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/cargo/warehouse)
 "atZ" = (
@@ -5606,6 +5603,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/cargo/warehouse)
 "avh" = (
@@ -5633,6 +5631,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "avk" = (
@@ -5682,7 +5681,6 @@
 /area/cargo/miningdock)
 "avr" = (
 /obj/machinery/door/airlock/mining/glass{
-	cyclelinkeddir = 8;
 	name = "Mining Dock";
 	req_access_txt = "48"
 	},
@@ -5693,7 +5691,6 @@
 /area/cargo/miningdock)
 "avs" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 4;
 	name = "Mining Dock Airlock";
 	req_access = null;
 	req_access_txt = "48";
@@ -5840,10 +5837,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "avZ" = (
-/obj/structure/dresser,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/carpet,
-/area/command/bridge)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "awd" = (
 /obj/machinery/door/airlock/medical{
 	name = "Chief Medical Officer's Personal Quarters";
@@ -5929,6 +5925,7 @@
 /area/command/bridge)
 "awt" = (
 /obj/effect/landmark/event_spawn,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/cargo/warehouse)
 "awu" = (
@@ -5961,7 +5958,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "awy" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -5975,7 +5972,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "awB" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/west,
@@ -6248,7 +6245,8 @@
 /mob/living/simple_animal/bot/mulebot{
 	beacon_freq = 1400;
 	home_destination = "QM #1";
-	suffix = "#1"
+	suffix = "#1";
+	name = "The Little Lost Mulebot"
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -6267,10 +6265,12 @@
 	home_destination = "QM #4";
 	suffix = "#2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "axm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "axn" = (
@@ -6578,13 +6578,13 @@
 /area/command/bridge)
 "ays" = (
 /obj/structure/window/reinforced,
-/obj/machinery/computer{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/window/reinforced{
 	dir = 8
+	},
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/command/bridge)
@@ -6614,7 +6614,7 @@
 "ayw" = (
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "ayx" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6695,6 +6695,7 @@
 	freq = 1400;
 	location = "QM #2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ayN" = (
@@ -6708,6 +6709,7 @@
 	freq = 1400;
 	location = "QM #5"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ayP" = (
@@ -6740,6 +6742,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ayS" = (
@@ -6858,7 +6861,6 @@
 /area/security/lockers)
 "azh" = (
 /obj/machinery/door/airlock/security/glass{
-	cyclelinkeddir = 2;
 	id_tag = null;
 	name = "Evidence Storage";
 	req_access_txt = "0";
@@ -6951,7 +6953,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -7120,10 +7121,10 @@
 /area/maintenance/department/bridge)
 "azY" = (
 /obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/cargo/warehouse)
 "azZ" = (
@@ -7248,7 +7249,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "aAo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7435,7 +7436,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "aAP" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/fore/greater)
@@ -9111,15 +9112,15 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "aFz" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	name = "Auxiliary Airlock"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "whiteship-dock"
 	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/external/aft)
 "aFA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -9481,7 +9482,7 @@
 	name = "Cargo RC";
 	pixel_y = 30
 	},
-/obj/machinery/rnd/production/protolathe/department/cargo,
+/obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/iron,
 /area/cargo/office)
 "aGx" = (
@@ -9527,33 +9528,18 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "aGB" = (
-/obj/structure/sign/poster/random{
-	name = "random official poster";
-	pixel_y = 32;
-	random_basetype = /obj/structure/sign/poster/official
-	},
 /obj/machinery/modular_computer/console/preset/cargochat/cargo,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/office)
 "aGC" = (
 /turf/closed/wall,
 /area/security/checkpoint/supply)
 "aGD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
+/turf/closed/wall,
+/area/maintenance/central/lesser)
 "aGE" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 32
@@ -10148,7 +10134,6 @@
 /area/security/prison)
 "aIs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -10377,23 +10362,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aIZ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/east,
+/obj/structure/rack,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/treatment_center)
 "aJa" = (
 /obj/structure/cable,
 /turf/open/floor/grass,
@@ -10635,6 +10610,14 @@
 /area/cargo/office)
 "aJD" = (
 /obj/machinery/disposal/bin,
+/obj/structure/sign/poster/random{
+	name = "random official poster";
+	pixel_y = -32;
+	random_basetype = /obj/structure/sign/poster/official
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "aJE" = (
@@ -10672,9 +10655,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -10786,7 +10766,6 @@
 /area/security/brig)
 "aJV" = (
 /obj/machinery/door/airlock/security/glass{
-	cyclelinkeddir = 2;
 	id_tag = "outterbrig";
 	name = "Brig";
 	req_access_txt = "0";
@@ -11731,7 +11710,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aMN" = (
@@ -11746,7 +11724,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aMO" = (
@@ -11764,7 +11741,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aMP" = (
@@ -11949,15 +11925,13 @@
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aNj" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aNk" = (
@@ -11969,15 +11943,13 @@
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aNl" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aNm" = (
@@ -11996,17 +11968,13 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "aNo" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+	dir = 1
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "aNp" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -12124,19 +12092,19 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "aNH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/painting/library{
-	pixel_x = 28
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/carpet,
-/area/service/library)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "aNJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -12181,7 +12149,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aNM" = (
@@ -12363,6 +12330,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
 "aOs" = (
@@ -12490,23 +12458,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aOI" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "aOJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -12924,6 +12881,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
 "aPt" = (
@@ -13543,7 +13501,7 @@
 /turf/open/floor/engine{
 	name = "reinforced floor"
 	},
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "aQT" = (
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -13592,11 +13550,10 @@
 /area/mine/explored)
 "aQZ" = (
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "aRb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -13607,7 +13564,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "aRc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -13638,14 +13595,14 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "aRf" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "aRg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 1
@@ -13734,7 +13691,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "aRr" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -13807,7 +13764,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "aRE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -14032,7 +13989,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "aSl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -14194,7 +14151,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/aft/greater)
+/area/maintenance/solars/starboard/aft)
 "aSC" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/sand/plating,
@@ -14332,14 +14289,10 @@
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aSS" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix Output";
-	on = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aST" = (
@@ -14416,15 +14369,13 @@
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aTc" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aTd" = (
@@ -14442,19 +14393,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "aTg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8;
-	name = "Cargo Atmospherics Checkpoint";
-	req_access_txt = "24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/maintenance/solars/starboard/aft)
 "aTh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -14464,15 +14405,13 @@
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "aTi" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "aTj" = (
@@ -14948,14 +14887,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/starboard";
-	dir = 8;
-	name = "Starboard Hallway APC";
-	pixel_x = -25;
-	pixel_y = 1
-	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "aUD" = (
@@ -15104,14 +15035,10 @@
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aVe" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix Input";
-	on = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aVf" = (
@@ -15137,9 +15064,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "aVi" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -15181,19 +15106,15 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "aVp" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aVq" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aVr" = (
@@ -15295,9 +15216,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/greater)
 "aVJ" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -15364,24 +15283,18 @@
 /area/ai_monitored/command/nuke_storage)
 "aVR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1;
-	name = "Command Atmospherics Checkpoint";
-	req_access_txt = "24"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aVS" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "aVT" = (
@@ -15449,7 +15362,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "aWk" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/effect/turf_decal/sand/plating,
@@ -15493,7 +15406,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "aWu" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-09"
@@ -15558,9 +15471,10 @@
 /area/hallway/primary/starboard)
 "aWG" = (
 /obj/machinery/power/solar{
-	id = "commandsolar";
+	id = "foresolar";
 	name = "Fore Solar Array"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/solars/port/fore)
 "aWH" = (
@@ -15576,7 +15490,6 @@
 /area/maintenance/solars/port/fore)
 "aWJ" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 4;
 	name = "Solar Maintenance";
 	req_access = null;
 	req_access_txt = "10; 13"
@@ -15666,7 +15579,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "aXb" = (
 /obj/item/stack/cable_coil{
 	amount = 2
@@ -15724,7 +15637,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "aXx" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -15846,7 +15759,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "aYl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -15901,9 +15814,7 @@
 /turf/closed/wall,
 /area/hallway/primary/port)
 "aYx" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -15978,13 +15889,11 @@
 /turf/closed/wall,
 /area/hallway/primary/central)
 "aYK" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "aYL" = (
 /obj/machinery/door/airlock/glass,
 /obj/effect/turf_decal/tile/neutral{
@@ -15993,7 +15902,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "aYM" = (
 /obj/machinery/door/airlock/glass,
 /obj/effect/turf_decal/tile/neutral{
@@ -16008,7 +15917,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "aYN" = (
 /obj/machinery/door/airlock/glass,
 /obj/effect/turf_decal/tile/neutral{
@@ -16018,13 +15927,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "aYO" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "aYP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
@@ -16104,9 +16011,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aYY" = (
@@ -16172,13 +16076,13 @@
 /obj/machinery/light/small/directional/east,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "aZl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "aZm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -16208,7 +16112,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "aZq" = (
 /turf/closed/wall,
 /area/hallway/primary/starboard)
@@ -16245,10 +16149,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"aZu" = (
+/obj/structure/cable,
+/obj/machinery/stasis,
+/turf/open/floor/iron,
+/area/medical/treatment_center)
 "aZv" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -16341,17 +16248,15 @@
 /area/service/hydroponics/garden)
 "aZK" = (
 /turf/closed/mineral/random/stationside/asteroid/porus,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "aZL" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "aZN" = (
 /turf/closed/wall,
 /area/mine/explored)
@@ -16371,16 +16276,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central/aft)
 "aZR" = (
-/obj/machinery/power/solar{
-	id = "foresolar";
-	name = "Fore Solar Array"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/iron/solarpanel/airless,
-/area/solars/starboard/fore)
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "aZT" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/stripes/end,
@@ -16478,13 +16380,13 @@
 /area/service/hydroponics/garden)
 "bah" = (
 /turf/open/floor/plating/asteroid,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bai" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/flashlight/seclite,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "baj" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -16494,11 +16396,11 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bak" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bal" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Engineering Asteroid Hallway 7";
@@ -16509,13 +16411,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bam" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "ban" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -16529,11 +16431,11 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bao" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bap" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -16690,11 +16592,11 @@
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating/asteroid,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "baM" = (
 /obj/structure/table,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "baN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -16715,7 +16617,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "baP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -16728,12 +16630,12 @@
 /area/hallway/secondary/entry)
 "baQ" = (
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "baR" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "baS" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/eva)
@@ -16858,6 +16760,12 @@
 	},
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
+"bbn" = (
+/obj/item/stack/cable_coil{
+	amount = 2
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/starboard/aft)
 "bbp" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table,
@@ -16870,32 +16778,32 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bbr" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/asteroid,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bbs" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/rack,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bbt" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bbu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bbv" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/space/fragile,
 /obj/item/clothing/head/helmet/space/fragile,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bbw" = (
 /obj/structure/table,
 /obj/item/stack/sheet/rglass{
@@ -17044,7 +16952,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bbQ" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4;
@@ -17053,7 +16961,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bbR" = (
 /obj/machinery/door/airlock/maintenance/external{
 	name = "External Airlock Access";
@@ -17064,14 +16972,14 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bbS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bbU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
@@ -17081,7 +16989,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bbV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -17095,7 +17003,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bbW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
@@ -17105,7 +17013,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bbY" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel/fifty{
@@ -17293,7 +17201,7 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bcD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17311,7 +17219,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bcE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17322,21 +17230,21 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bcF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bcG" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bcH" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bcI" = (
 /obj/structure/closet/crate/rcd,
 /turf/open/floor/iron,
@@ -17597,7 +17505,7 @@
 	layer = 4
 	},
 /turf/closed/wall,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bdv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -17605,9 +17513,8 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bdw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -17618,14 +17525,16 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bdx" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
-/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/hallway/primary/starboard)
 "bdy" = (
 /obj/structure/rack,
 /obj/item/tank/jetpack/carbondioxide,
@@ -17868,7 +17777,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "beh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -17878,14 +17787,14 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bei" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bej" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
@@ -17898,7 +17807,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bel" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
@@ -17914,7 +17823,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bem" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -17935,7 +17844,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "ben" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
@@ -17947,7 +17856,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "beo" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17968,7 +17877,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "beq" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/yellow/full,
@@ -17986,7 +17895,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bes" = (
 /turf/closed/wall,
 /area/ai_monitored/command/storage/eva)
@@ -18141,7 +18050,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "beW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -18159,7 +18068,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "beX" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
@@ -18175,7 +18084,7 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "beY" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/observer_start,
@@ -18196,7 +18105,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "beZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
@@ -18211,7 +18120,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bfd" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -18225,7 +18134,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bfe" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=EngineeringEast2";
@@ -18244,7 +18153,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bff" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue,
@@ -18252,7 +18161,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bfg" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
@@ -18276,9 +18185,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -18558,7 +18464,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bga" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Engineering Asteroid Hallway 3";
@@ -18568,21 +18474,19 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bgb" = (
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "bgc" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "bgd" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -18593,7 +18497,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bge" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -18604,29 +18508,27 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bgf" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "bgg" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "bgh" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32;
 	pixel_y = -32
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bgi" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=EngineeringWest";
@@ -18645,7 +18547,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bgj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -18657,7 +18559,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bgk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -18881,6 +18783,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bgP" = (
@@ -19013,18 +18916,12 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bhd" = (
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "bhf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -19034,7 +18931,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bhg" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -19286,7 +19183,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bhT" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19299,7 +19196,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bhU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
@@ -19309,7 +19206,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bhV" = (
 /obj/structure/table,
 /obj/item/stack/rods{
@@ -19422,6 +19319,7 @@
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bii" = (
@@ -19718,8 +19616,7 @@
 /area/maintenance/port/fore)
 "bjm" = (
 /obj/machinery/conveyor/auto{
-	dir = 6;
-	flipped = 1
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -19814,7 +19711,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bjB" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -19834,7 +19731,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bjD" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -19852,12 +19749,12 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bjF" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bjG" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -19943,11 +19840,6 @@
 	},
 /area/command/heads_quarters/cmo)
 "bjN" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/machinery/airalarm/directional/north{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -19958,8 +19850,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/medical/patients_rooms)
+/area/medical/cryo)
 "bjO" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral{
@@ -20240,15 +20134,12 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "bkz" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bkA" = (
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter)
@@ -20262,7 +20153,7 @@
 "bkF" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bkG" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -20279,11 +20170,6 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "bkJ" = (
-/obj/item/folder/red{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -20294,9 +20180,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 5
+	},
 /turf/open/floor/iron,
-/area/medical/patients_rooms)
+/area/medical/cryo)
 "bkK" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -20464,13 +20352,13 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "blh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bli" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -20479,7 +20367,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "blj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -20489,7 +20377,7 @@
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "blk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -20498,7 +20386,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bll" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -20515,7 +20403,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "blm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -20527,7 +20415,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "blq" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -20573,7 +20461,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "blw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -20582,7 +20470,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "blx" = (
 /obj/machinery/light/directional/south,
 /obj/structure/reflector/single/anchored{
@@ -20609,7 +20497,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "blB" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -20684,31 +20572,28 @@
 	},
 /area/command/heads_quarters/cmo)
 "blJ" = (
-/obj/machinery/button/door{
-	id = "medp1";
-	name = "Privacy Shutters";
-	pixel_x = -24
-	},
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/area/medical/cryo)
 "blK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/area/medical/cryo)
 "blL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -20716,9 +20601,13 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/area/medical/cryo)
 "blM" = (
 /obj/machinery/button/door{
 	id = "medp2";
@@ -20777,7 +20666,7 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "blT" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation A";
@@ -20965,9 +20854,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "bmp" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -20989,7 +20876,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8;
 	name = "Service Atmospherics Checkpoint";
 	req_access_txt = "24"
 	},
@@ -21006,17 +20892,15 @@
 /turf/open/space,
 /area/space/nearstation)
 "bmu" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bmv" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -21024,19 +20908,17 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bmw" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bmx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -21049,14 +20931,14 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bmy" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bmz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera{
@@ -21070,7 +20952,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bmB" = (
 /obj/structure/reflector/single/anchored{
 	dir = 4
@@ -21097,7 +20979,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bmG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
@@ -21112,17 +20994,15 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "bmJ" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bmK" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -21130,7 +21010,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bmL" = (
 /turf/closed/wall/rust,
 /area/maintenance/department/engine/atmos)
@@ -21146,27 +21026,23 @@
 /turf/open/space,
 /area/space/nearstation)
 "bmP" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "bmR" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "bmS" = (
@@ -21242,22 +21118,26 @@
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "bnb" = (
-/obj/machinery/door/airlock/medical{
-	name = "Patient Room";
-	req_access_txt = "5"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1;
+	icon_state = "warningline"
 	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/turf/open/floor/iron,
+/area/medical/cryo)
 "bnc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "medp1"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1;
+	icon_state = "warningline"
 	},
-/turf/open/floor/plating,
-/area/medical/patients_rooms)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/medical/cryo)
 "bnd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -21267,7 +21147,7 @@
 /area/medical/patients_rooms)
 "bne" = (
 /obj/machinery/door/airlock/medical{
-	name = "Patient Room 2";
+	name = "Patient Room";
 	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21597,7 +21477,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bnQ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 1
@@ -21623,7 +21503,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bnZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -21640,7 +21520,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "boa" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Teleporter";
@@ -21702,7 +21582,6 @@
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "boi" = (
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -21710,8 +21589,26 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/wrench/medical,
 /turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/area/medical/medbay/central)
 "boj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -21740,6 +21637,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "bom" = (
@@ -21999,7 +21899,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "boX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -22015,7 +21915,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bpa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -22123,7 +22023,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bpl" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering Asteroid Hallway 6"
@@ -22132,7 +22032,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bpm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22145,7 +22045,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bpn" = (
 /obj/machinery/modular_computer/console/preset/cargochat/service,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -22408,11 +22308,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bpM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/closed/wall/r_wall,
+/area/hallway/secondary/construction/engineering)
 "bpN" = (
 /obj/machinery/vending/medical,
 /obj/effect/turf_decal/tile/blue{
@@ -22665,7 +22562,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bqn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
@@ -22685,7 +22582,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bqp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -22700,7 +22597,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bqq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/east,
@@ -22711,7 +22608,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bqr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22835,7 +22732,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bqF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22858,7 +22755,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bqG" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
@@ -23073,21 +22970,20 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bqY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/machinery/vending/wallmed{
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/requests_console{
-	announcementConsole = 0;
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC";
-	pixel_y = -30
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "bqZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -23260,7 +23156,6 @@
 /area/medical/virology)
 "brl" = (
 /obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4;
 	name = "Medical Escape Pod"
 	},
 /obj/effect/turf_decal/sand/plating,
@@ -23271,7 +23166,6 @@
 /area/maintenance/department/medical)
 "brn" = (
 /obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4;
 	name = "Medical Escape Pod"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -23559,14 +23453,14 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "brR" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "brS" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
@@ -23574,7 +23468,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "brT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
@@ -23584,7 +23478,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "brU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -23601,7 +23495,7 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "brV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
@@ -23609,13 +23503,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "brW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "brX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
@@ -23635,7 +23529,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "brY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -23647,7 +23541,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "brZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23695,7 +23589,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bsg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -23703,7 +23597,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bsh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -23711,7 +23605,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bsi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -23726,7 +23620,7 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bsj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
@@ -23734,25 +23628,25 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bsk" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bsl" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bsm" = (
 /obj/machinery/door/airlock/glass,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bsn" = (
 /obj/machinery/door/airlock/glass,
 /obj/effect/turf_decal/tile/neutral{
@@ -24138,7 +24032,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bto" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral{
@@ -24156,7 +24050,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "btp" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
@@ -24318,9 +24212,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "btJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance{
@@ -24427,17 +24320,13 @@
 /turf/open/floor/iron,
 /area/medical/treatment_center)
 "btW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/engine,
+/area/hallway/primary/central)
 "btX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -24670,17 +24559,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "buH" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
-/area/hallway/secondary)
+/area/hallway/primary/central/aft)
 "buI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -24689,29 +24570,20 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "buJ" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
 "buL" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "buM" = (
@@ -24721,13 +24593,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "buN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "buO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -24737,7 +24609,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "buP" = (
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -22
@@ -24745,7 +24617,7 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "buQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/navbeacon{
@@ -24762,13 +24634,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "buR" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "buS" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light/small/directional/west,
@@ -24839,7 +24711,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bve" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=EngineeringEast3";
@@ -24857,7 +24729,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bvf" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -24867,7 +24739,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bvh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
@@ -24908,9 +24780,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bvm" = (
@@ -24939,6 +24809,9 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/heavy,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bvp" = (
@@ -24952,14 +24825,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8;
-	name = "Medbay Atmospherics Checkpoint";
-	req_access_txt = "24"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "bvr" = (
@@ -24992,6 +24861,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "bvu" = (
@@ -25032,6 +24902,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "bvx" = (
@@ -25119,9 +24990,21 @@
 /turf/open/floor/iron,
 /area/medical/treatment_center)
 "bvI" = (
-/obj/effect/turf_decal/tile/blue/full,
-/turf/open/floor/iron,
-/area/medical/treatment_center)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark,
+/area/medical/cryo)
 "bvJ" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -25235,7 +25118,7 @@
 	},
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bwi" = (
 /turf/closed/wall/r_wall,
 /area/engineering/break_room)
@@ -25267,7 +25150,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bwl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -25396,6 +25279,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "bwB" = (
@@ -25417,6 +25301,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "bwE" = (
@@ -25475,12 +25360,11 @@
 /turf/open/floor/iron,
 /area/medical/medbay/lobby)
 "bwK" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Medbay";
-	req_access_txt = "45"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay";
+	req_access_txt = "5"
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bwL" = (
@@ -25496,8 +25380,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bwM" = (
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/machinery/light/directional/west,
 /obj/structure/table/glass,
 /turf/open/floor/iron,
@@ -25517,30 +25399,16 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "bwO" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
+"bwP" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"bwP" = (
-/obj/machinery/camera{
-	c_tag = "Cyrotubes";
-	dir = 6
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/cryo_cell{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/medical/treatment_center)
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "bwQ" = (
 /turf/open/floor/iron,
 /area/security/lockers)
@@ -25686,15 +25554,13 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "bxm" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bxn" = (
 /obj/structure/table,
 /obj/item/seeds/chili,
@@ -25742,7 +25608,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bxu" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -25750,7 +25616,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bxv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
@@ -25764,7 +25630,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bxw" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -25773,7 +25639,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bxx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -25935,6 +25801,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "bxS" = (
@@ -25964,17 +25831,12 @@
 /area/medical/medbay/lobby)
 "bxU" = (
 /obj/machinery/cell_charger,
-/obj/item/wrench/medical,
 /obj/structure/table/glass,
 /turf/open/floor/iron,
 /area/medical/treatment_center)
 "bxW" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/medical/treatment_center)
+/turf/closed/wall,
+/area/hallway/secondary/construction/engineering)
 "bxX" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/light_switch/directional/east,
@@ -26087,7 +25949,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
@@ -26147,18 +26008,18 @@
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "byu" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "byw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "byx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -26166,14 +26027,14 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "byy" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "byz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26258,6 +26119,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "byO" = (
@@ -26333,8 +26195,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "byW" = (
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/radio/intercom/directional/west,
 /obj/structure/table/glass,
 /turf/open/floor/iron,
@@ -26351,14 +26211,14 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "byY" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/medical/treatment_center)
+/area/hallway/primary/starboard)
 "byZ" = (
 /obj/machinery/camera{
 	c_tag = "Medbay West";
@@ -26376,6 +26236,10 @@
 "bza" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/hallway/primary/starboard)
 "bzb" = (
@@ -26538,14 +26402,14 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/main)
 "bzu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bzv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
@@ -26556,7 +26420,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bzw" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -26569,7 +26433,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bzx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
 	dir = 10
@@ -26660,13 +26524,6 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bzJ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/engineering";
-	dir = 4;
-	name = "Engineering Security Checkpoint APC";
-	pixel_x = 23;
-	pixel_y = 2
-	},
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -26676,12 +26533,14 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bzK" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "bzL" = (
@@ -26857,11 +26716,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "medmain";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
@@ -26870,6 +26724,14 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "medmain";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bzW" = (
@@ -26927,7 +26789,6 @@
 /area/medical/treatment_center)
 "bAb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -27072,7 +26933,7 @@
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engineering/break_room)
+/area/engineering/main)
 "bAE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
 	dir = 9
@@ -27089,13 +26950,13 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/main)
 "bAF" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bAH" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -27104,7 +26965,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bAI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden,
 /turf/closed/wall/r_wall,
@@ -27233,7 +27094,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bAU" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -27295,6 +27156,7 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "bBd" = (
@@ -27381,15 +27243,18 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bBl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "medmain";
 	name = "Medbay";
 	req_access_txt = "5"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bBm" = (
@@ -27469,21 +27334,17 @@
 	req_one_access_txt = "10;11;12"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/hallway/primary/starboard)
 "bBs" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/medical/medbay/central)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai)
 "bBt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -27491,13 +27352,6 @@
 /area/medical/medbay/central)
 "bBu" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/syringes,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -27557,7 +27411,7 @@
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/main)
 "bBK" = (
 /obj/structure/table,
 /obj/item/storage/box/cups,
@@ -27566,7 +27420,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bBL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden,
 /obj/machinery/status_display{
@@ -27704,7 +27558,7 @@
 /area/hallway/primary/starboard)
 "bCg" = (
 /turf/closed/wall,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bCh" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/neutral/full,
@@ -27719,7 +27573,7 @@
 "bCj" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/plating,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bCk" = (
 /obj/machinery/button/door{
 	id = "medmain";
@@ -27859,9 +27713,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "bCG" = (
@@ -27877,17 +27728,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "bCI" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/bot,
+/obj/machinery/rnd/production/techfab/department/engineering,
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/main)
 "bCJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bCK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -27897,7 +27748,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bCL" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/tile/yellow,
@@ -27905,7 +27756,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bCM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
 	dir = 5
@@ -28115,7 +27966,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bDk" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -28131,7 +27982,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bDl" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -28257,6 +28108,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bDz" = (
@@ -28417,7 +28269,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bDZ" = (
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/yellow,
@@ -28428,7 +28280,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bEa" = (
 /obj/machinery/light/directional/north,
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -28459,7 +28311,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bEf" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -28542,13 +28394,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bEt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bEu" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -28561,14 +28413,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bEv" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bEw" = (
 /obj/structure/chair{
 	dir = 4
@@ -28577,7 +28429,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bEx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -28873,7 +28725,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bFh" = (
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -28886,7 +28738,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bFj" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -28896,7 +28748,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bFn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -29116,14 +28968,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bFH" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bFI" = (
 /obj/machinery/chem_heater,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -29134,7 +28986,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bFJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -29144,7 +28996,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bFK" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
@@ -29168,13 +29020,8 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bFN" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Chemistry Lab";
-	req_access_txt = "5; 33"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -29184,8 +29031,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/door/airlock/research/glass{
+	name = "Pharmacy";
+	req_access_txt = "5; 69"
+	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bFO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -29542,7 +29393,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "atmodesk"
 	},
@@ -29563,10 +29413,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/heavy,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bGP" = (
@@ -29583,7 +29431,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bGQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -29592,7 +29440,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bGR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29605,7 +29453,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bGS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -29622,7 +29470,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bGT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -29849,7 +29697,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bHm" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/yellow{
@@ -29862,7 +29710,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bHn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -29875,7 +29723,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bHp" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -29886,11 +29734,11 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bHq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bHr" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue{
@@ -30090,7 +29938,7 @@
 "bHO" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bHP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -30299,7 +30147,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bIq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -30308,7 +30156,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bIr" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/yellow,
@@ -30319,7 +30167,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bIs" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -30333,7 +30181,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bIt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -30457,7 +30305,7 @@
 	},
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bIM" = (
 /obj/structure/table/glass,
 /obj/item/hand_labeler_refill,
@@ -30469,7 +30317,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bIN" = (
 /obj/structure/table/glass,
 /obj/item/stack/cable_coil,
@@ -30481,7 +30329,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bIO" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
@@ -30497,7 +30345,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bIP" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -30509,14 +30357,14 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bIQ" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bIR" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes,
@@ -30528,7 +30376,7 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bIS" = (
 /obj/structure/table/glass,
 /obj/item/grenade/chem_grenade,
@@ -30543,20 +30391,19 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "bIV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Medbay Storage";
-	req_access_txt = "45"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
+	req_access_txt = "5"
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "bIW" = (
@@ -31148,7 +30995,7 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange,
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bKB" = (
@@ -31364,9 +31211,6 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "bLA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -31959,7 +31803,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/rnd/production/protolathe/department/medical,
+/obj/machinery/rnd/production/techfab/department/medical,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "bMM" = (
@@ -32174,6 +32018,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bNt" = (
@@ -32592,14 +32437,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "bOD" = (
 /obj/machinery/power/smes/engineering,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "bOE" = (
 /obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8;
 	req_one_access_txt = "24"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -33046,16 +32890,14 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "bPO" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "bQa" = (
 /obj/effect/turf_decal/tile/yellow/anticorner,
 /turf/open/floor/iron/white,
@@ -33148,7 +32990,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bQq" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/camera{
@@ -33458,7 +33300,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "bRh" = (
 /obj/machinery/light/directional/west,
 /obj/item/kirbyplants{
@@ -34494,9 +34336,7 @@
 /turf/open/floor/plating/asteroid,
 /area/maintenance/department/medical)
 "bTO" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -34530,21 +34370,29 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bTU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/service/theater)
 "bTV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/starboard)
 "bTX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -34894,9 +34742,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "bVe" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -35151,9 +34997,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bVF" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -35162,9 +35006,7 @@
 /turf/open/floor/plating/asteroid,
 /area/maintenance/port/fore)
 "bVH" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -35374,9 +35216,7 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel)
 "bWs" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -35592,9 +35432,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bXe" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -35815,6 +35653,7 @@
 "bXT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "bXU" = (
@@ -36694,11 +36533,9 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "cbt" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/commons/fitness/recreation)
 "cbu" = (
@@ -36710,11 +36547,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "cbv" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "cbw" = (
@@ -36816,13 +36651,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cbT" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/commons/fitness/recreation)
 "cbU" = (
@@ -36843,7 +36676,7 @@
 /turf/open/floor/engine{
 	name = "reinforced floor"
 	},
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "ccd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -36865,7 +36698,7 @@
 	},
 /obj/structure/girder,
 /turf/open/floor/plating,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cch" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4;
@@ -36891,7 +36724,7 @@
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cck" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -36899,14 +36732,10 @@
 "ccn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2;
-	name = "Arrivals Atmospherics Checkpoint";
-	req_access_txt = "24"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cco" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/lattice/catwalk,
@@ -36922,13 +36751,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "ccr" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "ccs" = (
@@ -36954,7 +36781,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "ccw" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -36981,13 +36808,13 @@
 /turf/open/floor/engine{
 	name = "reinforced floor"
 	},
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "ccA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "ccB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37003,11 +36830,9 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "ccD" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -37019,6 +36844,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
 "ccG" = (
@@ -37038,7 +36864,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "ccI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -37048,14 +36874,14 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "ccJ" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "ccK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -37090,21 +36916,21 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "ccR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "ccS" = (
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "ccT" = (
 /obj/item/storage/bag/ore,
 /obj/item/pickaxe/mini,
@@ -37134,6 +36960,7 @@
 "cda" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/sand/plating,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
 "cdb" = (
@@ -37161,7 +36988,7 @@
 /turf/open/floor/engine{
 	name = "reinforced floor"
 	},
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cdd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
@@ -37171,7 +36998,7 @@
 /turf/open/floor/engine{
 	name = "reinforced floor"
 	},
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cde" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -37181,11 +37008,11 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cdf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cdg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
@@ -37195,11 +37022,11 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cdk" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cdl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -37209,7 +37036,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cdm" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -37230,7 +37057,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cdp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -37243,7 +37070,7 @@
 	req_access_txt = "24"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cdq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -37255,7 +37082,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cdr" = (
 /obj/machinery/door/airlock/hatch{
 	name = "AI Core Hallway";
@@ -37295,13 +37122,13 @@
 "cdt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/aft/greater)
+/area/maintenance/solars/starboard/aft)
 "cdu" = (
 /turf/closed/wall/r_wall,
-/area/maintenance/aft/greater)
+/area/maintenance/solars/starboard/aft)
 "cdv" = (
 /turf/closed/wall/r_wall/rust,
-/area/maintenance/aft/greater)
+/area/maintenance/solars/starboard/aft)
 "cdw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/directional/west{
@@ -37311,7 +37138,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cdy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
@@ -37340,7 +37167,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cdB" = (
 /obj/machinery/door/airlock/hatch{
 	name = "AI Core";
@@ -37374,7 +37201,7 @@
 /obj/item/paper/guides/jobs/engi/solars,
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plating,
-/area/maintenance/aft/greater)
+/area/maintenance/solars/starboard/aft)
 "cdE" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -37382,7 +37209,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/maintenance/aft/greater)
+/area/maintenance/solars/starboard/aft)
 "cdF" = (
 /obj/machinery/power/smes,
 /obj/structure/sign/warning/securearea{
@@ -37393,7 +37220,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/maintenance/aft/greater)
+/area/maintenance/solars/starboard/aft)
 "cdH" = (
 /obj/structure/chair/stool{
 	dir = 8
@@ -37403,7 +37230,6 @@
 /area/security/prison)
 "cdM" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 4;
 	name = "Solar Maintenance";
 	req_access = null;
 	req_access_txt = "10; 13"
@@ -37413,10 +37239,9 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/aft/greater)
+/area/maintenance/solars/starboard/aft)
 "cdO" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 8;
 	name = "Solar Maintenance";
 	req_access = null;
 	req_access_txt = "10; 13"
@@ -37426,7 +37251,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/aft/greater)
+/area/maintenance/solars/starboard/aft)
 "cdS" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/disposalpipe/segment,
@@ -37434,7 +37259,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cdT" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
@@ -37464,7 +37289,6 @@
 /area/cargo/storage)
 "cdX" = (
 /obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4;
 	name = "Command Escape Pod"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -37525,9 +37349,8 @@
 "cef" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "ceg" = (
@@ -37546,9 +37369,8 @@
 	id = "portsolar";
 	name = "Aft Asteroid Solar Control"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/maintenance/aft/greater)
+/area/maintenance/solars/starboard/aft)
 "cek" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 8;
@@ -37557,7 +37379,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/plating,
-/area/maintenance/aft/greater)
+/area/maintenance/solars/starboard/aft)
 "cem" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen";
@@ -37714,14 +37536,12 @@
 /turf/closed/wall,
 /area/cargo/miningdock)
 "ceI" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/structure/barricade/wooden,
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "ceJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -37747,7 +37567,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/aft/greater)
+/area/maintenance/solars/starboard/aft)
 "ceL" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating/asteroid,
@@ -37826,15 +37646,13 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ceU" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
 "ceV" = (
@@ -37898,13 +37716,13 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "cfe" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/grimy,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "cff" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -37912,12 +37730,12 @@
 /obj/item/pickaxe/mini,
 /obj/item/gun/energy/kinetic_accelerator,
 /turf/open/floor/iron/grimy,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "cfg" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "cfh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -37936,7 +37754,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cfm" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/asteroid,
@@ -37947,7 +37765,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "cfq" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 4;
 	name = "Solar Maintenance";
 	req_access = null;
 	req_access_txt = "10; 13"
@@ -37960,7 +37777,6 @@
 /area/maintenance/solars/port/fore)
 "cfr" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 4;
 	name = "Solar Maintenance";
 	req_access = null;
 	req_access_txt = "10; 13"
@@ -37972,18 +37788,15 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "cfs" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "cft" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -38000,13 +37813,8 @@
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "cfz" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/ai_upload";
-	dir = 1;
-	name = "Tech Storage APC";
-	pixel_y = 24
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "cfA" = (
@@ -38020,34 +37828,32 @@
 /obj/item/clothing/head/cone,
 /obj/item/clothing/head/cone,
 /turf/open/floor/iron/grimy,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "cfC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "cfD" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "cfE" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "cfF" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/structure/barricade/wooden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "cfG" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -38111,39 +37917,31 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "cfU" = (
-/obj/machinery/door/airlock/external{
-	cyclelinkeddir = 8;
-	name = "Security Escape Airlock";
-	req_access_txt = "2"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "cfV" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "cfW" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "cfX" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "cfY" = (
@@ -38153,9 +37951,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "cfZ" = (
@@ -38182,7 +37978,6 @@
 "cgc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1;
 	name = "Research Atmospherics Checkpoint";
 	req_access_txt = "24"
 	},
@@ -38224,24 +38019,24 @@
 /obj/item/storage/bag/ore,
 /obj/item/storage/bag/ore,
 /turf/open/floor/plating,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "cgi" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
 /obj/item/paper/fluff,
 /turf/open/floor/iron/grimy,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "cgj" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/iron/grimy,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "cgk" = (
 /turf/open/floor/iron/grimy,
 /area/cargo/miningdock)
 "cgl" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "cgm" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
@@ -38266,9 +38061,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "cgy" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -38276,13 +38069,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "cgz" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "cgA" = (
@@ -38414,7 +38205,7 @@
 /obj/item/stack/ore/iron,
 /obj/item/stack/ore/gold,
 /turf/open/floor/plating,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "cgS" = (
 /obj/machinery/light/small,
 /obj/structure/table,
@@ -38425,7 +38216,7 @@
 	amount = 5
 	},
 /turf/open/floor/plating,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "chf" = (
 /obj/machinery/airalarm/directional/west{
 	pixel_x = -23
@@ -38449,27 +38240,24 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "chj" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "chk" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "chm" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -38523,7 +38311,6 @@
 "cht" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 1;
 	req_access_txt = "24"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -38608,13 +38395,11 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "chL" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "chM" = (
@@ -38770,7 +38555,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cil" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/wood,
@@ -38938,7 +38723,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "ciL" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/sand/plating,
@@ -38976,7 +38761,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "ciP" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39238,7 +39023,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cjC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line,
@@ -39577,8 +39362,6 @@
 "ckH" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/tcomms_all,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "ckI" = (
@@ -39598,16 +39381,22 @@
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "ckK" = (
-/obj/machinery/door/airlock/external{
-	cyclelinkeddir = 8;
-	name = "Security Escape Airlock";
-	req_access_txt = "2"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "ckL" = (
 /obj/machinery/door/airlock/highsecurity{
 	locked = 0;
@@ -39622,9 +39411,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "ckM" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -39692,7 +39479,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "ckX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral,
@@ -39834,9 +39621,7 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/aft)
 "clw" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -39848,9 +39633,7 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "cly" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -39949,7 +39732,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "clN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood{
@@ -40064,7 +39847,7 @@
 "cme" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cmf" = (
 /turf/closed/wall,
 /area/hallway/secondary/entry)
@@ -40275,7 +40058,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cmx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -40296,7 +40079,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cmy" = (
 /turf/closed/wall/rust,
 /area/maintenance/aft/lesser)
@@ -40355,7 +40138,6 @@
 /area/space)
 "cmG" = (
 /obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4;
 	name = "Research Escape Pod"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -40365,7 +40147,6 @@
 /area/hallway/primary/aft)
 "cmH" = (
 /obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8;
 	name = "Research Escape Pod"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -40708,14 +40489,12 @@
 /turf/open/floor/plating,
 /area/commons/vacant_room/office)
 "cnF" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
@@ -41460,7 +41239,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central/aft)
 "coV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41468,7 +41247,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central/aft)
 "coW" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/disposalpipe/segment{
@@ -41604,7 +41383,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cpk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock{
@@ -41803,7 +41582,7 @@
 /obj/structure/girder,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
-/area/hallway/secondary)
+/area/hallway/primary/central/aft)
 "cpD" = (
 /obj/machinery/status_display{
 	density = 0;
@@ -42041,9 +41820,7 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/solars/starboard/aft)
 "cqg" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -42698,7 +42475,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/rnd/production/protolathe/department/science,
+/obj/machinery/rnd/production/techfab/department/science,
 /turf/open/floor/iron,
 /area/science/lab)
 "crC" = (
@@ -42870,9 +42647,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
@@ -42994,7 +42768,6 @@
 	dir = 9
 	},
 /obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side{
 	dir = 6
@@ -43327,13 +43100,8 @@
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "csS" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/robotics/mechbay";
-	dir = 4;
-	name = "Mech Bay APC";
-	pixel_x = 26
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "csT" = (
@@ -43373,10 +43141,10 @@
 /turf/open/floor/iron,
 /area/science/lab)
 "csW" = (
-/obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /turf/open/floor/iron,
 /area/science/lab)
 "csX" = (
@@ -43920,21 +43688,17 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "cun" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cuo" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cup" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -44818,7 +44582,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cwb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -45058,12 +44822,11 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "cww" = (
@@ -45114,17 +44877,13 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "cwE" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/science/robotics/lab)
+/area/hallway/primary/starboard)
 "cwF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
@@ -45393,9 +45152,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -45470,8 +45226,10 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cxD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cxF" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -45489,7 +45247,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cxG" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/neutral{
@@ -47325,7 +47083,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "cCy" = (
 /obj/item/assembly/mousetrap/armed,
 /turf/open/floor/plating,
@@ -47343,9 +47101,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cCD" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "disposals_airlock"
@@ -47384,7 +47140,7 @@
 /obj/machinery/conveyor/auto,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "cCL" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/breath,
@@ -47393,13 +47149,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "cCM" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "cCN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -47435,7 +47191,7 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "cDf" = (
 /obj/structure/table,
 /obj/item/cultivator,
@@ -47468,18 +47224,18 @@
 	flipped = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "cDo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "cDp" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "cDA" = (
 /obj/structure/table,
 /obj/item/weldingtool/mini,
@@ -47512,7 +47268,7 @@
 	random_basetype = /obj/structure/sign/poster/official
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "cDL" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/asteroid,
@@ -47524,7 +47280,7 @@
 	flipped = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "cDO" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -47533,7 +47289,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "cEb" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 8
@@ -47690,6 +47446,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/locker)
 "cED" = (
@@ -47865,7 +47622,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cFh" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/sign/poster/random{
@@ -47900,7 +47657,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cFk" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
@@ -47921,6 +47678,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "cFm" = (
@@ -47980,7 +47741,7 @@
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cFt" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
@@ -47988,7 +47749,7 @@
 "cFu" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "cFv" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -48003,7 +47764,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cFx" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating/asteroid,
@@ -48053,6 +47814,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cFD" = (
@@ -48093,12 +47855,12 @@
 	name = "Officer Pipsqueak's Home"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cFK" = (
 /obj/structure/bed/dogbed,
 /mob/living/simple_animal/bot/secbot/beepsky/jr,
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cFL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/warning/securearea{
@@ -48110,7 +47872,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "cFM" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
@@ -48282,6 +48044,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cGi" = (
@@ -48651,7 +48414,6 @@
 /area/security/brig)
 "cHe" = (
 /obj/machinery/door/airlock/security/glass{
-	cyclelinkeddir = 2;
 	id_tag = "innerbrig";
 	name = "Brig";
 	req_access_txt = "0";
@@ -48720,7 +48482,6 @@
 /area/security/brig)
 "cHn" = (
 /obj/machinery/door/airlock/security/glass{
-	cyclelinkeddir = 2;
 	id_tag = "outterbrig";
 	name = "Brig";
 	req_access_txt = "0";
@@ -48862,7 +48623,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "cHJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -49030,7 +48791,7 @@
 "cIm" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cIn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -49045,7 +48806,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cIo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -49061,7 +48822,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cIp" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -49097,7 +48858,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cIu" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -49152,7 +48913,7 @@
 "cIz" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cIA" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/engine/atmos)
@@ -49172,7 +48933,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cIC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
 	dir = 4
@@ -49218,7 +48979,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cIL" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/asteroid,
@@ -49247,7 +49008,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cIO" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/disposalpipe/segment{
@@ -49265,7 +49026,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cIS" = (
 /obj/item/assembly/mousetrap/armed,
 /obj/effect/turf_decal/sand/plating,
@@ -49331,7 +49092,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cJg" = (
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron/dark/textured_large,
@@ -49518,7 +49279,7 @@
 "cJC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central/aft)
 "cJD" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -49721,6 +49482,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cKi" = (
@@ -49902,6 +49664,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
 "cKR" = (
@@ -49921,9 +49684,11 @@
 /turf/open/floor/plating/asteroid,
 /area/maintenance/department/bridge)
 "cKW" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/fore/greater)
+/obj/machinery/atmospherics/pipe/bridge_pipe/general/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "cKX" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -50011,6 +49776,7 @@
 	c_tag = "Cargo Hall West";
 	network = list("SS13","QM")
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cLr" = (
@@ -50555,12 +50321,10 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "cNr" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "cNs" = (
@@ -50886,7 +50650,7 @@
 /area/command/heads_quarters/cmo)
 "cOj" = (
 /turf/closed/wall/r_wall,
-/area/medical/patients_rooms)
+/area/medical/cryo)
 "cOl" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/turf_decal/stripes/line{
@@ -51175,7 +50939,7 @@
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cOY" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -51334,12 +51098,6 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "cPs" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/morgue";
-	dir = 1;
-	name = "Morgue APC";
-	pixel_y = 24
-	},
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
@@ -51348,6 +51106,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "cPz" = (
@@ -51559,7 +51318,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
@@ -51802,7 +51560,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8;
 	req_access_txt = "8"
 	},
 /turf/open/floor/plating,
@@ -51831,7 +51588,7 @@
 "cRn" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cRt" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -52500,7 +52257,6 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "cTT" = (
-/obj/machinery/rnd/production/circuit_imprinter,
 /obj/machinery/requests_console{
 	department = "Robotics";
 	departmentType = 2;
@@ -52509,6 +52265,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "cTV" = (
@@ -52558,7 +52315,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cUe" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
@@ -52678,6 +52435,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cUJ" = (
@@ -52685,6 +52443,7 @@
 	capacity = 9e+006;
 	charge = 10000
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cUK" = (
@@ -52865,6 +52624,7 @@
 "cVt" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "cVu" = (
@@ -53098,7 +52858,7 @@
 	c_tag = "Command-Service Bridge"
 	},
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cWn" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Command-Engineering Bridge";
@@ -53106,95 +52866,101 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cWp" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cWs" = (
+/obj/structure/chair/wood,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/engine,
-/area/hallway/secondary)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/service/theater)
 "cWu" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cWw" = (
 /obj/machinery/light/directional/east,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cWx" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/directional/west{
 	c_tag = "Medbay-Cargo Bridge"
 	},
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cWC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cWD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cWH" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Service-Engineering Bridge 1"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cWK" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Service-Engineering Bridge 2"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cWL" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cWM" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cWO" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Medbay-Engineering Bridge"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cWP" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/engine,
-/area/hallway/secondary)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "cWQ" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Medbay-Engineering Bridge 2"
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cWR" = (
-/turf/closed/wall,
-/area/hallway/secondary)
+/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/cargo/office)
 "cWX" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Docking-Medbay Bridge";
@@ -53202,12 +52968,12 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cXa" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cXc" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Docking-Medbay Bridge 2";
@@ -53215,7 +52981,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cXd" = (
 /obj/machinery/door/airlock/glass,
 /obj/effect/turf_decal/tile/neutral,
@@ -53246,11 +53012,11 @@
 /area/hallway/primary/starboard)
 "cXh" = (
 /turf/closed/wall/r_wall,
-/area/hallway/secondary)
+/area/hallway/primary/central/aft)
 "cXj" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central/aft)
 "cXm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -53271,7 +53037,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central/aft)
 "cXo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53282,13 +53048,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central/aft)
 "cXp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cXq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53299,7 +53065,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central/aft)
 "cXr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53310,7 +53076,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central/aft)
 "cXt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/lattice/catwalk,
@@ -53320,22 +53086,22 @@
 /obj/machinery/light/small/directional/west,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "cXA" = (
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "cXB" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Core-Command-Cargo Bridge 1";
 	network = list("SS13")
 	},
 /turf/open/floor/engine,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "cXF" = (
 /turf/closed/wall/r_wall,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "cXH" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Core-Command-Cargo Bridge 2";
@@ -53343,15 +53109,15 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "cXJ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/engine,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "cXK" = (
 /turf/open/floor/engine,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "cXL" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Core-Command-Cargo Bridge 3";
@@ -53359,7 +53125,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "cXM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -53382,27 +53148,27 @@
 "cXO" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "cXP" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "cXQ" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "cXS" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
 /turf/open/floor/plating,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "cXT" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cXU" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cXW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -53417,7 +53183,7 @@
 /area/hallway/primary/port)
 "cXX" = (
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cXZ" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/asteroid,
@@ -53427,25 +53193,22 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "cYe" = (
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/engine{
-	name = "reinforced floor"
-	},
-/area/hallway/secondary)
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cYg" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine{
 	name = "reinforced floor"
 	},
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cYh" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "cYi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -53467,6 +53230,7 @@
 	icon_state = "warn_end"
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "cYl" = (
@@ -53510,6 +53274,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "cYs" = (
@@ -53574,6 +53339,23 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
+"daO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "dbO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -54626,6 +54408,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"deS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "deY" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "armoryaccess";
@@ -54996,6 +54785,7 @@
 "djz" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/structure/crate,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "djB" = (
@@ -55537,13 +55327,8 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "dlI" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/processing";
-	dir = 4;
-	name = "Labor Shuttle Dock APC";
-	pixel_x = 24
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/security/processing)
 "dlJ" = (
@@ -55827,6 +55612,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/grimy,
 /area/security/prison)
 "dmM" = (
@@ -55986,6 +55772,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/grimy,
 /area/security/prison)
 "dnX" = (
@@ -56142,6 +55929,7 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
 "doB" = (
@@ -56166,6 +55954,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/general/hidden{
 	dir = 8
 	},
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/grimy,
 /area/security/prison)
 "doH" = (
@@ -56465,6 +56254,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/grimy,
 /area/security/prison)
 "dpM" = (
@@ -56823,6 +56613,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/grimy,
 /area/security/prison)
 "dqO" = (
@@ -57099,6 +56890,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
 	},
+/obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/grimy,
 /area/security/prison)
 "dsa" = (
@@ -57858,6 +57650,15 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
+"dvd" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/turretid{
+	control_area = "/area/ai_monitored/turret_protected/ai_upload";
+	name = "AI Upload turret control";
+	pixel_y = 25
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "dve" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -58269,7 +58070,6 @@
 /area/security/detectives_office)
 "dwz" = (
 /obj/machinery/door/airlock/security/glass{
-	cyclelinkeddir = 2;
 	id_tag = "innerbrig";
 	name = "Brig";
 	req_access_txt = "0";
@@ -58446,13 +58246,8 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "dxm" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/detectives_office";
-	dir = 4;
-	name = "Detective's Office APC";
-	pixel_x = 24
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "dxn" = (
@@ -58593,6 +58388,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "dxN" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/external/aft)
 "dxO" = (
@@ -58979,7 +58775,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway)
+/area/hallway/primary/central/fore)
 "dzi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -59063,7 +58859,6 @@
 /area/hallway/primary/aft)
 "dzt" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 4;
 	name = "Solar Maintenance";
 	req_access = null;
 	req_access_txt = "10; 13"
@@ -59414,6 +59209,13 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/requests_console{
+	announcementConsole = 0;
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC";
+	pixel_y = -30
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dAe" = (
@@ -59805,7 +59607,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "dBq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -59813,7 +59615,7 @@
 	name = "Chemistry Lobby Shutters"
 	},
 /turf/open/floor/plating,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "dBs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -59830,7 +59632,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "dBu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -59911,7 +59713,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "dBz" = (
 /obj/machinery/airalarm/directional/north{
 	pixel_y = 23
@@ -59920,7 +59722,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "dBA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -59935,7 +59737,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "dBH" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/effect/turf_decal/sand/plating,
@@ -59952,7 +59754,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "dBJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -59962,13 +59764,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "dBL" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "dBM" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/yellow{
@@ -59978,7 +59780,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "dBN" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -59993,7 +59795,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "dBO" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -60520,8 +60322,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "dQn" = (
-/turf/open/floor/plating/asteroid,
-/area/mine/explored)
+/obj/machinery/door/airlock/glass,
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "dRf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -60544,7 +60350,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "dTM" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/iron/grimy,
@@ -60554,7 +60360,9 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/upper)
 "dVD" = (
-/obj/machinery/power/smes/engineering,
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/external/aft)
 "dVF" = (
@@ -60608,8 +60416,9 @@
 "ecv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "ecU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -60627,6 +60436,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"efr" = (
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/grimy,
+/area/cargo/warehouse)
 "egB" = (
 /obj/machinery/door/airlock/maintenance/external{
 	name = "External Airlock Access";
@@ -60669,6 +60483,11 @@
 /obj/structure/rack,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/department/medical)
+"ekz" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard/greater)
 "elj" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -60775,6 +60594,12 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"eBh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "eBB" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -60828,12 +60653,14 @@
 "eGM" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/external/aft)
 "eIm" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "eJy" = (
 /obj/machinery/quantumpad,
 /turf/open/floor/iron/dark,
@@ -60846,6 +60673,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/port/aft)
+"ePn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard/greater)
 "eQc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
@@ -60853,6 +60688,11 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating,
 /area/engineering/atmos/project)
+"eQv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "eRt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61037,6 +60877,10 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/aft/greater)
+"foH" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "fpY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
@@ -61055,7 +60899,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "fsD" = (
 /obj/structure/table,
 /obj/item/hand_labeler{
@@ -61090,6 +60934,9 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/aft/greater)
+"fBl" = (
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "fEW" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/grimy,
@@ -61104,7 +60951,11 @@
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
+"fHO" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "fIZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61142,20 +60993,34 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "fOI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/airlock/glass,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "fQx" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/weldingtool,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "fQR" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/external/aft)
 "fRb" = (
@@ -61210,7 +61075,7 @@
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "get" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1;
@@ -61235,6 +61100,13 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/department/cargo)
+"ggW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai)
 "ghw" = (
 /obj/effect/baseturf_helper/asteroid,
 /obj/structure/disposalpipe/segment{
@@ -61342,6 +61214,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"gwq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/locker)
 "gxx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -61438,6 +61317,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"gLi" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/grimy,
+/area/hallway/primary/starboard)
 "gLW" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -61485,10 +61369,23 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"gOu" = (
+/obj/machinery/door/airlock/external/glass,
+/turf/closed/wall,
+/area/hallway/primary/port)
 "gPp" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard/greater)
+"gPG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/upper)
 "gQf" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Aft Asteroid Maintenance";
@@ -61504,6 +61401,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "gRS" = (
@@ -61539,6 +61437,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/storage)
+"gTX" = (
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "gUr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -61676,7 +61582,6 @@
 /area/security/brig)
 "hkW" = (
 /obj/machinery/door/airlock/security/glass{
-	cyclelinkeddir = 2;
 	id_tag = "innerbrig";
 	name = "Brig Checkpoint";
 	req_access_txt = "0";
@@ -61726,7 +61631,7 @@
 	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "hst" = (
 /obj/machinery/door/airlock{
 	id_tag = "Toilet1";
@@ -61777,6 +61682,16 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"hDf" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "hEa" = (
 /obj/effect/baseturf_helper/asteroid,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -61797,6 +61712,11 @@
 	name = "reinforced floor"
 	},
 /area/engineering/supermatter)
+"hFN" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/cargo/office)
 "hGk" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/structure/window/reinforced{
@@ -61814,6 +61734,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"hGF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "hGJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
 	dir = 9
@@ -61825,6 +61754,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "hIU" = (
@@ -61859,6 +61789,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/supermatter)
+"hKo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/external{
+	name = "External Airlock Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "hKt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61900,7 +61840,7 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "hPg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -61977,8 +61917,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "hWi" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -62067,7 +62008,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/pharmacy)
 "idJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -62089,8 +62030,14 @@
 /area/maintenance/department/science)
 "ifV" = (
 /obj/machinery/light/small/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
+"igK" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "igR" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -62127,6 +62074,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
+"ija" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "ijd" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
@@ -62135,6 +62091,10 @@
 "ijz" = (
 /turf/open/floor/plating/asteroid,
 /area/maintenance/aft/greater)
+"ijL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/grimy,
+/area/hallway/primary/starboard)
 "ijO" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating/asteroid,
@@ -62183,7 +62143,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "iol" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Fore Asteroid Maintenance Access";
@@ -62191,6 +62151,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"ipy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard/greater)
 "ipL" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating/asteroid,
@@ -62199,6 +62163,11 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"irB" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "irU" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating/asteroid,
@@ -62266,9 +62235,7 @@
 /turf/open/floor/wood,
 /area/service/library/lounge)
 "izR" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -62346,14 +62313,13 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "iHZ" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8;
 	req_one_access_txt = "24"
 	},
 /turf/open/floor/plating,
@@ -62388,6 +62354,22 @@
 /obj/structure/table,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"iKZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "iLf" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 4;
@@ -62421,16 +62403,19 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "iNd" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/medical/treatment_center)
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "iNR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"iOW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/grimy,
+/area/cargo/warehouse)
 "iPk" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/sand/plating,
@@ -62470,6 +62455,7 @@
 /obj/machinery/light/dim/directional/north,
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/booze,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/external/aft)
 "jdb" = (
@@ -62526,7 +62512,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/engineering/break_room)
+/area/engineering/main)
 "jjJ" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -62534,6 +62520,7 @@
 "jjZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/commons/toilet/locker)
 "jls" = (
@@ -62567,7 +62554,9 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "jmn" = (
@@ -62605,6 +62594,10 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/port/aft)
+"jrc" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/engine,
+/area/hallway/primary/central/aft)
 "jro" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
@@ -62647,7 +62640,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "jxa" = (
 /obj/structure/girder,
 /obj/effect/turf_decal/sand/plating,
@@ -62698,6 +62691,13 @@
 "jCF" = (
 /turf/open/floor/plating,
 /area/space/nearstation)
+"jDR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "jFA" = (
 /turf/closed/mineral/random/stationside/asteroid/porus,
 /area/maintenance)
@@ -62754,6 +62754,16 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"jMA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1;
+	icon_state = "warningline"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/medical/cryo)
 "jMF" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -62762,7 +62772,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "jNa" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/bed/roller,
@@ -62813,6 +62823,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"jTv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/cargo/office)
 "jUk" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/grimy,
@@ -63031,6 +63052,7 @@
 "krn" = (
 /obj/effect/spawner/random/structure/crate_empty,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/cargo/warehouse)
 "krR" = (
@@ -63045,16 +63067,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"kts" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "ktP" = (
-/obj/machinery/computer/turbine_computer{
-	dir = 1;
-	id = "incineratorturbine"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plating,
+/area/hallway/secondary/construction/engineering)
 "kvv" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/neutral{
@@ -63178,6 +63206,12 @@
 "kGq" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"kGS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "kHj" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
@@ -63194,7 +63228,7 @@
 "kIT" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "kIY" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating/asteroid,
@@ -63209,11 +63243,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "kNu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/turf/closed/wall,
+/area/medical/cryo)
 "kRG" = (
 /obj/effect/baseturf_helper/asteroid,
 /obj/effect/turf_decal/sand/plating,
@@ -63248,7 +63279,7 @@
 "kUG" = (
 /obj/item/wrench,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "kVw" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -63332,9 +63363,9 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "leq" = (
-/obj/effect/baseturf_helper/asteroid,
-/turf/closed/wall,
-/area/maintenance/department/science)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/cargo/office)
 "lfq" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 1;
@@ -63357,9 +63388,7 @@
 /turf/open/floor/plating/asteroid,
 /area/maintenance/department/engine)
 "lhg" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -63429,10 +63458,15 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/starboard/lesser)
+"lqz" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/baseturf_helper/asteroid,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "lqQ" = (
 /obj/machinery/conveyor/auto,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "lqW" = (
 /obj/machinery/space_heater,
 /obj/structure/cable,
@@ -63447,9 +63481,7 @@
 /turf/open/floor/plating,
 /area/command/gateway)
 "lvu" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -63472,6 +63504,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"lxV" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "lAp" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -63483,8 +63524,15 @@
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "lBY" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/closed/wall,
+/obj/machinery/camera{
+	c_tag = "Cyrotubes";
+	dir = 6
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/structure/table/glass,
+/obj/structure/bedsheetbin,
+/turf/open/floor/iron,
 /area/medical/treatment_center)
 "lCn" = (
 /obj/structure/table,
@@ -63501,7 +63549,7 @@
 "lDf" = (
 /obj/structure/grille/broken,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "lFc" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/grimy,
@@ -63543,6 +63591,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
+"lHT" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard/greater)
 "lKo" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
@@ -63555,11 +63608,10 @@
 /area/maintenance/aft/upper)
 "lLO" = (
 /obj/machinery/conveyor/auto{
-	dir = 6;
-	flipped = 1
+	dir = 6
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "lMp" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -63588,7 +63640,7 @@
 "lPY" = (
 /obj/effect/baseturf_helper/asteroid,
 /turf/open/floor/plating,
-/area/maintenance/aft/greater)
+/area/maintenance/solars/starboard/aft)
 "lRk" = (
 /obj/structure/table/wood,
 /obj/item/nullrod,
@@ -63650,7 +63702,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "lXK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -63722,6 +63774,7 @@
 /area/engineering/atmos/project)
 "maJ" = (
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/cargo/warehouse)
 "mbP" = (
@@ -63867,6 +63920,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
+"mvr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "mvV" = (
 /obj/effect/baseturf_helper/asteroid,
 /obj/effect/turf_decal/tile/brown{
@@ -63920,6 +63980,13 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos/project)
+"myn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "mys" = (
 /obj/effect/turf_decal/box/white{
 	color = "#9FED58"
@@ -64054,7 +64121,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "mKv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/firecloset/full,
@@ -64111,6 +64178,14 @@
 "mTy" = (
 /turf/closed/mineral/random/stationside/asteroid/porus,
 /area/maintenance/port/aft)
+"mTO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "mUh" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -64248,7 +64323,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "njM" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
@@ -64275,6 +64350,7 @@
 "nmu" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/external/aft)
 "nnL" = (
@@ -64294,8 +64370,20 @@
 /turf/open/floor/iron,
 /area/medical/medbay/lobby)
 "noa" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat/maint)
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "npy" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
@@ -64318,6 +64406,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"npM" = (
+/obj/structure/table,
+/obj/item/wrench,
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "nqz" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -64387,6 +64485,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"nuh" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/engine,
+/area/hallway/primary/central)
 "nuB" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -64395,7 +64497,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "nwl" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/corner{
@@ -64423,7 +64525,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "nBi" = (
 /obj/effect/baseturf_helper/asteroid,
 /obj/structure/disposalpipe/segment{
@@ -64500,11 +64602,11 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "nGt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
+/area/cargo/storage)
 "nHy" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -64641,7 +64743,7 @@
 /turf/open/floor/engine{
 	name = "reinforced floor"
 	},
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "obV" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -64669,9 +64771,8 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "odW" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/turf/open/floor/iron/grimy,
+/area/maintenance/central/lesser)
 "oeX" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -64796,7 +64897,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "oue" = (
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
@@ -64830,6 +64931,15 @@
 "owx" = (
 /turf/closed/mineral/random/stationside/asteroid/porus,
 /area/maintenance/aft/greater)
+"oyc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "engineeringlockdown";
+	layer = 2.6;
+	name = "Emergency Lockdown Blastdoor"
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "oyu" = (
 /obj/item/assembly/mousetrap/armed,
 /turf/open/floor/plating,
@@ -64854,7 +64964,6 @@
 /area/maintenance/disposal/incinerator)
 "oBa" = (
 /obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8;
 	req_access_txt = "8"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -64927,17 +65036,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "oHu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/turf/open/floor/engine,
+/area/hallway/primary/central/aft)
 "oHZ" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -64965,9 +65065,7 @@
 /turf/open/floor/iron/grimy,
 /area/maintenance/department/security)
 "oIw" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -65059,17 +65157,13 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/entry)
 "oOd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/turf/closed/wall/rust,
+/area/maintenance/fore/upper)
 "oPd" = (
-/obj/structure/chair/stool,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
+/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore/upper)
 "oQB" = (
 /turf/closed/mineral/random/stationside/asteroid/porus,
 /area/maintenance/starboard/lesser)
@@ -65090,7 +65184,7 @@
 "oRA" = (
 /obj/effect/baseturf_helper/asteroid,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "oSH" = (
 /obj/machinery/computer/teleporter{
 	dir = 8
@@ -65122,12 +65216,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/upper)
+"oYK" = (
+/obj/effect/spawner/random/structure/crate_empty,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/grimy,
+/area/cargo/warehouse)
 "oZN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "paa" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/shower{
@@ -65189,7 +65290,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "pgh" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -65217,6 +65318,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"pjG" = (
+/obj/machinery/stasis,
+/turf/open/floor/iron,
+/area/medical/treatment_center)
 "pkQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -65289,6 +65394,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"pqz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/greater)
 "prJ" = (
 /obj/structure/marker_beacon/burgundy,
 /turf/open/floor/plating/asteroid/airless,
@@ -65319,7 +65433,12 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
+"psF" = (
+/obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "pta" = (
 /obj/machinery/newscaster/directional/east,
 /obj/effect/landmark/xeno_spawn,
@@ -65375,7 +65494,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "pAt" = (
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plating,
@@ -65421,6 +65540,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"pFt" = (
+/obj/structure/chair/stool,
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "pFU" = (
 /obj/structure/closet/firecloset/full,
 /obj/item/coin/silver,
@@ -65439,9 +65562,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
@@ -65477,6 +65597,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "pJd" = (
@@ -65650,7 +65771,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "qah" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -65726,7 +65847,7 @@
 	random_basetype = /obj/structure/sign/poster/contraband
 	},
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "qjs" = (
 /turf/open/floor/iron/grimy,
 /area/maintenance/department/security)
@@ -65772,13 +65893,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "qoZ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Incinerator to Output";
-	on = 0
-	},
-/turf/open/space,
-/area/space)
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "qpB" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/asteroid,
@@ -65935,6 +66053,21 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/science/mixing)
+"qEi" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
+/turf/open/floor/iron/dark,
+/area/medical/cryo)
 "qEk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
@@ -65944,6 +66077,29 @@
 /obj/item/assembly/mousetrap/armed,
 /turf/open/floor/plating,
 /area/maintenance/aft/greater)
+"qEE" = (
+/obj/machinery/door/airlock/glass,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
+"qET" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "qFs" = (
 /obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
@@ -65987,12 +66143,17 @@
 /obj/machinery/iv_drip,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "qLw" = (
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/maintenance/department/science)
+"qLR" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "qLW" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -66013,7 +66174,7 @@
 /obj/effect/baseturf_helper/asteroid,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/cargo/miningdock)
+/area/maintenance/central/lesser)
 "qON" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/tile/purple/half,
@@ -66028,10 +66189,8 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "qPP" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/maint)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "qQK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen/ordnance{
@@ -66067,6 +66226,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/extinguisher,
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "qVE" = (
@@ -66077,6 +66237,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"qXh" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "qXy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -66095,6 +66264,25 @@
 /obj/item/stack/sheet/iron,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/fore/lesser)
+"qYq" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "qZK" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -66116,6 +66304,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"rcp" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/starboard/greater)
 "rcs" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -66129,6 +66322,10 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"rdS" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/fore/upper)
 "reP" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/effect/turf_decal/sand/plating,
@@ -66179,7 +66376,7 @@
 "rjQ" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "rmI" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -66224,6 +66421,15 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"rtp" = (
+/obj/structure/table,
+/obj/item/wrench,
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "rud" = (
 /turf/open/floor/iron/grimy,
 /area/maintenance/department/engine)
@@ -66414,6 +66620,7 @@
 /area/security/lockers)
 "rUc" = (
 /obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/external/aft)
 "rUx" = (
@@ -66429,6 +66636,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/medical)
+"rVe" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "rWa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -66474,6 +66692,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/greater)
+"saV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "sbP" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -66488,7 +66712,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "seF" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/asteroid,
@@ -66533,8 +66757,8 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "snY" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -66544,7 +66768,13 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/secondary)
+/area/hallway/primary/central)
+"spv" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/grimy,
+/area/hallway/primary/starboard)
 "spy" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/iron,
@@ -66616,7 +66846,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "ssP" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
@@ -66641,12 +66871,12 @@
 "svz" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "svC" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/table,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "swP" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -66750,6 +66980,12 @@
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/iron/textured,
 /area/maintenance/department/engine/atmos)
+"sHa" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore/upper)
 "sIc" = (
 /obj/effect/baseturf_helper/asteroid,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -66763,15 +66999,23 @@
 	},
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/binary/pump/on,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "sKX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/bottle/multiver,
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = -3
 	},
-/turf/open/floor/plating,
+/obj/item/reagent_containers/syringe{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/turf/open/floor/iron,
 /area/medical/treatment_center)
 "sLC" = (
 /turf/closed/mineral/random/labormineral,
@@ -66837,6 +67081,10 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/department/science)
+"sPE" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/locker)
 "sQY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -66887,7 +67135,7 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "taY" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -66960,7 +67208,7 @@
 	pixel_x = 24
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "tlR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
@@ -67026,7 +67274,7 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange,
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tCe" = (
@@ -67034,6 +67282,7 @@
 /area/maintenance/department/bridge)
 "tDi" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/external/aft)
 "tDA" = (
@@ -67103,7 +67352,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "tNb" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/disposalpipe/segment,
@@ -67114,7 +67363,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "tNW" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
@@ -67194,7 +67443,7 @@
 /obj/structure/table,
 /obj/item/pickaxe,
 /turf/open/floor/plating,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "tWl" = (
 /obj/effect/baseturf_helper/asteroid,
 /turf/open/floor/plating/asteroid,
@@ -67207,7 +67456,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/main)
 "tWI" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/light/small/directional/north,
@@ -67230,7 +67479,7 @@
 	},
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "tYv" = (
 /obj/structure/toilet{
 	pixel_y = 8
@@ -67273,6 +67522,12 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/department/medical)
+"uet" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "ueO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67301,12 +67556,17 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/external/aft)
 "uhX" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"ujd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "ujO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -67339,8 +67599,14 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
 "upG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/external/aft)
+"uqX" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/engineering/main)
 "usI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67356,11 +67622,11 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "uuF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "uvC" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 4
@@ -67454,14 +67720,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
 "uHv" = (
-/obj/effect/turf_decal/stripes/asteroid/end{
-	dir = 1
-	},
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/turf/open/floor/plating/asteroid,
-/area/maintenance/department/science)
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/cargo/office)
 "uHN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67531,12 +67793,11 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "uRq" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 4
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/external/aft)
 "uRs" = (
@@ -67596,6 +67857,11 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"uTG" = (
+/obj/item/inducer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/maintenance/external/aft)
 "uUf" = (
 /turf/closed/wall/rust,
 /area/maintenance/aft/greater)
@@ -67646,7 +67912,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "uZl" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/disposalpipe/segment{
@@ -67674,17 +67940,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "vgd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 8
+/turf/closed/wall,
+/area/maintenance/fore/upper)
+"vgL" = (
+/obj/machinery/computer/turbine_computer{
+	dir = 1;
+	id = "incineratorturbine"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "viq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67724,7 +67988,7 @@
 "vls" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "vlJ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -67733,7 +67997,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "vlV" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -67774,6 +68038,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "vmN" = (
@@ -67806,8 +68071,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "vsE" = (
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "vsY" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating/asteroid,
@@ -67818,7 +68084,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "vtL" = (
 /obj/structure/sign/poster/random{
 	name = "random contraband poster";
@@ -67827,6 +68093,13 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/maintenance/port/aft)
+"vvP" = (
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "vyI" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -67837,8 +68110,9 @@
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "vAH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/baseturf_helper/asteroid,
@@ -67851,6 +68125,9 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"vCm" = (
+/turf/closed/wall/r_wall,
+/area/engineering/main)
 "vDb" = (
 /obj/structure/grille,
 /turf/open/space,
@@ -67939,6 +68216,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/commons/toilet/locker)
+"vLF" = (
+/obj/machinery/door/airlock/glass,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "vNr" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
@@ -67946,11 +68231,11 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/maintenance/department/bridge)
 "vOR" = (
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "vPB" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Fore Asteroid Maintenance Access";
@@ -68065,6 +68350,7 @@
 /area/space/nearstation)
 "wfi" = (
 /obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/external/aft)
 "wfu" = (
@@ -68102,7 +68388,14 @@
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating/airless,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
+"wiv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "wiZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68123,6 +68416,7 @@
 /obj/effect/decal/cleanable/glass,
 /obj/item/storage/toolbox/electrical,
 /obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/external/aft)
 "woR" = (
@@ -68219,6 +68513,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"wBa" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/medical/cryo)
 "wDA" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/closet/l3closet,
@@ -68254,11 +68554,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
 "wGW" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/baseturf_helper/asteroid,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -68269,13 +68564,14 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
 /turf/open/floor/iron,
-/area/medical/patients_rooms)
+/area/medical/cryo)
 "wGX" = (
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "wHS" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
@@ -68318,7 +68614,7 @@
 	},
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/secondary/entry)
 "wMH" = (
 /obj/machinery/shower{
 	dir = 1
@@ -68373,13 +68669,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/department/engine/atmos)
+"wPU" = (
+/obj/structure/cable,
+/turf/open/floor/iron/grimy,
+/area/maintenance/solars/starboard/aft)
 "wQt" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 2
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/maintenance/fore/greater)
 "wRA" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/grimy,
@@ -68488,7 +68787,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "xbV" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
@@ -68552,8 +68851,15 @@
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/bot,
 /obj/machinery/iv_drip,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"xhB" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/space/fragile,
+/obj/item/clothing/head/helmet/space/fragile,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "xhN" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -68618,7 +68924,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/grimy,
-/area/maintenance/disposal)
+/area/maintenance/fore/upper)
 "xrN" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
@@ -68644,21 +68950,30 @@
 /turf/open/floor/plating/asteroid,
 /area/maintenance/department/medical)
 "xyi" = (
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/commons/toilet/locker)
 "xyk" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Fore Asteroid Maintenance Access";
-	req_access_txt = "12"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
 	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "xzl" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"xzO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "xAP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -68670,8 +68985,7 @@
 /area/maintenance/port/aft)
 "xEp" = (
 /obj/machinery/conveyor/auto{
-	dir = 10;
-	flipped = 1
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -68702,7 +69016,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "xLk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -68765,7 +69079,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/central)
+/area/hallway/secondary/construction/engineering)
 "xPI" = (
 /obj/structure/barricade/wooden,
 /obj/effect/turf_decal/sand/plating,
@@ -68786,7 +69100,7 @@
 /area/space/nearstation)
 "xRT" = (
 /turf/closed/wall,
-/area/maintenance/disposal)
+/area/maintenance/port/lesser)
 "xRU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -68813,6 +69127,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
+"xUQ" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "xWP" = (
 /turf/closed/wall,
 /area/maintenance/aft/greater)
@@ -68832,7 +69150,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/hallway/secondary)
+/area/hallway/primary/central)
 "xYw" = (
 /obj/effect/turf_decal/tile/yellow/half{
 	dir = 1
@@ -68841,6 +69159,9 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"xYS" = (
+/turf/closed/wall/rust,
+/area/maintenance/port/lesser)
 "xZk" = (
 /turf/closed/wall/rust,
 /area/maintenance/disposal)
@@ -74815,7 +75136,7 @@ tXB
 cCK
 lqQ
 cDm
-xZk
+xYS
 xRT
 aaa
 aaa
@@ -75068,7 +75389,7 @@ aaa
 aaa
 xRT
 xRT
-xZk
+xYS
 cCL
 cDo
 lLO
@@ -75836,14 +76157,14 @@ aiL
 aiL
 aZO
 aZO
-aZO
+aZN
 alc
 aaa
 aaa
 xRT
-xZk
+xYS
 bgc
-xZk
+xYS
 cDO
 xRT
 aaa
@@ -76100,7 +76421,7 @@ aaa
 aaa
 xRT
 bgf
-xZk
+xYS
 amn
 xRT
 aaa
@@ -80700,9 +81021,9 @@ aaa
 aaa
 cJL
 cxz
-cqk
+cKW
 cwC
-cqk
+cKW
 csJ
 cto
 cJV
@@ -82117,7 +82438,7 @@ dyv
 dyI
 aOv
 lZm
-atS
+aQO
 aNX
 aSr
 aSr
@@ -82414,7 +82735,7 @@ cMT
 cMX
 cNk
 cNY
-bTu
+cWs
 cOb
 cMT
 bLx
@@ -82513,7 +82834,7 @@ cxU
 cyJ
 czr
 cxd
-cAo
+yfn
 yfn
 rLj
 lie
@@ -82770,8 +83091,8 @@ dkC
 cyK
 czs
 cxd
-cAo
-uHv
+yfn
+qTF
 cAU
 pSA
 jWk
@@ -83030,7 +83351,7 @@ cxd
 yfn
 qTF
 mpk
-leq
+cAU
 jWk
 jWk
 jWk
@@ -83158,18 +83479,18 @@ aNX
 spn
 spn
 spn
-cXh
+biL
 spn
 spn
 spn
-cXh
+biL
 spn
 xKH
-cXh
+biL
 spn
 spn
 spn
-cXh
+biL
 spn
 spn
 spn
@@ -83243,13 +83564,13 @@ xXK
 xXK
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
 xXK
@@ -83421,8 +83742,8 @@ cXX
 cXX
 cWl
 cXX
-ayw
-cWs
+cXX
+cXX
 cXX
 cXX
 cXX
@@ -83442,7 +83763,7 @@ baY
 bdN
 cNl
 bXZ
-bTV
+bdN
 bXZ
 bip
 bXZ
@@ -83452,7 +83773,7 @@ bXZ
 bnE
 bXZ
 bqd
-aGD
+bXZ
 bXZ
 bXZ
 bXZ
@@ -83530,7 +83851,7 @@ cpr
 cqt
 dCa
 cGU
-cwE
+cGU
 ctv
 cue
 cuC
@@ -83542,7 +83863,7 @@ cyM
 cuT
 rLj
 yfn
-yfn
+lqz
 qTF
 qTF
 cAU
@@ -83757,7 +84078,7 @@ cca
 cca
 cca
 cca
-aQR
+cca
 cca
 cca
 cca
@@ -84014,7 +84335,7 @@ cYg
 cYg
 cYg
 cYg
-cYe
+cYg
 cYg
 cYg
 cdd
@@ -84186,18 +84507,18 @@ aNX
 xXK
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
 xXK
@@ -84266,18 +84587,18 @@ aYw
 aYw
 aYw
 aYw
-aYw
+gOu
 xXK
 xXK
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
 xXK
@@ -84401,7 +84722,7 @@ cOC
 akb
 ajj
 adt
-aeD
+dnA
 dnA
 dnA
 dnA
@@ -86297,7 +86618,7 @@ bQi
 bKt
 bLH
 bLH
-aNH
+bLH
 bPg
 bQk
 bRl
@@ -87007,7 +87328,7 @@ rju
 tXc
 qAj
 aVC
-aWR
+fBl
 sZf
 aWA
 aWJ
@@ -87265,7 +87586,7 @@ qAj
 awu
 aUW
 dpk
-aWR
+fBl
 aVM
 aWI
 aWI
@@ -88537,7 +88858,7 @@ aFJ
 aHT
 cHp
 aPf
-aOI
+aPf
 aIY
 azp
 aOF
@@ -89258,9 +89579,9 @@ aaa
 aaa
 aaa
 aaa
-xRT
+vgd
 nuB
-xRT
+vgd
 alc
 alc
 alc
@@ -89269,7 +89590,7 @@ akx
 akx
 akx
 akx
-aZO
+aZN
 aZO
 aZO
 aZO
@@ -89515,10 +89836,10 @@ aaa
 aaa
 aaa
 aaa
-xRT
-amn
-xRT
-xRT
+vgd
+gPG
+vgd
+vgd
 aaa
 aaa
 cFp
@@ -89566,7 +89887,7 @@ aHV
 cKo
 cKo
 cKo
-aoW
+cKo
 aNL
 aPt
 aQu
@@ -89621,9 +89942,9 @@ cme
 cXp
 cXX
 ayw
-cWR
-buH
-cWR
+aYJ
+buL
+aYJ
 dcK
 ddc
 ddc
@@ -89772,11 +90093,11 @@ aaa
 aaa
 aaa
 aaa
-xRT
+vgd
 ses
 iGC
-xZk
-xRT
+oOd
+vgd
 aaa
 cFp
 cFp
@@ -89878,7 +90199,7 @@ cme
 cXp
 cXX
 ayw
-cWR
+aYJ
 buI
 ccj
 bxs
@@ -89945,7 +90266,7 @@ chU
 ciC
 chv
 chv
-aTW
+chv
 chv
 cfb
 cmX
@@ -90029,11 +90350,11 @@ aaa
 aaa
 aaa
 aaa
-xRT
+vgd
 abh
 xqZ
 abG
-xRT
+vgd
 aaa
 cFp
 cFp
@@ -90135,9 +90456,9 @@ cme
 cXp
 cXX
 ayw
-cWR
-buJ
-cWR
+aYJ
+cfX
+aYJ
 aZO
 aZO
 aZO
@@ -90290,7 +90611,7 @@ uuF
 ses
 iGC
 abH
-xRT
+vgd
 aaa
 cFp
 cFp
@@ -90388,11 +90709,11 @@ aaa
 aaa
 aaa
 aFt
-cXh
+biL
 cWC
 cXX
 ayw
-cXh
+biL
 bVd
 aaa
 aZO
@@ -90547,9 +90868,9 @@ uuF
 ses
 xqZ
 vOR
-xRT
-xRT
-xRT
+vgd
+vgd
+vgd
 akx
 akx
 akx
@@ -90804,17 +91125,17 @@ uuF
 ses
 xqZ
 vsE
-abX
+sHa
 ifV
 abX
-onQ
-onQ
-onQ
-onQ
-onQ
-onQ
-onQ
-onQ
+buJ
+buJ
+buJ
+buJ
+buJ
+buJ
+buJ
+buJ
 aZO
 aZO
 afd
@@ -91057,13 +91378,13 @@ aaa
 aaa
 aaa
 aaa
-xRT
+vgd
 abj
 usK
 oZN
-xZk
-xRT
-xRT
+oOd
+vgd
+vgd
 alc
 alc
 alc
@@ -91071,13 +91392,13 @@ alc
 alc
 alc
 alc
-pUZ
+bgr
 alc
-xRT
-xRT
-xZk
-xZk
-xZk
+aod
+aod
+asI
+asI
+asI
 adm
 afd
 alm
@@ -91088,11 +91409,11 @@ afd
 adm
 adm
 nVp
-anW
+irB
 ccF
 cda
 cda
-cIe
+deS
 dgU
 dpE
 dgU
@@ -91314,11 +91635,11 @@ aaa
 aaa
 aaa
 aaa
-xRT
+vgd
 abk
-eIm
-eIm
-abE
+rdS
+rdS
+oPd
 jwc
 aaa
 aaa
@@ -91328,13 +91649,13 @@ aaa
 aaa
 aaa
 alc
-pUZ
+bgr
 alc
 wil
 abE
 ssL
-kNu
-xRT
+cIe
+aod
 adm
 afd
 abK
@@ -91345,11 +91666,11 @@ afd
 adm
 dgU
 aPs
-cKW
+eIm
 ccW
 anW
 cKX
-dqm
+bwP
 dgU
 asI
 axV
@@ -91571,12 +91892,12 @@ aaa
 aaa
 aaa
 aaa
-xRT
-xRT
-xRT
-xRT
-xRT
-xRT
+vgd
+vgd
+vgd
+vgd
+vgd
+vgd
 alc
 alc
 alc
@@ -91585,13 +91906,13 @@ alc
 alc
 alc
 alc
-pUZ
+bgr
 alc
-xRT
-xRT
+aod
+aod
 peP
-ses
-xRT
+dqm
+aod
 adm
 afd
 abL
@@ -91600,13 +91921,13 @@ acl
 aeP
 afd
 aPs
-cKW
-dpP
+eIm
+afS
 dgU
 dgU
 dgU
 aod
-dqm
+bwP
 dgU
 asI
 azs
@@ -91673,11 +91994,11 @@ aaa
 aaa
 aaa
 aFt
-cXh
+biL
 cWC
 cXX
 cWH
-cXh
+biL
 aIk
 aaa
 aaa
@@ -91842,13 +92163,13 @@ aaa
 aaa
 aaa
 alc
-pUZ
-xRT
-xRT
-xRT
-xZk
-ses
-xRT
+bgr
+aod
+aod
+aod
+asI
+dqm
+aod
 adm
 afd
 abL
@@ -91856,14 +92177,14 @@ acj
 acr
 aeK
 afd
-dqm
+bwP
 dgU
 cKS
 dgU
 aod
 asI
 adm
-dqm
+bwP
 dgU
 asI
 axX
@@ -92099,13 +92420,13 @@ aaa
 aaa
 aaa
 alc
-pUZ
+bgr
 wQt
-ifV
+dgx
 cfs
-vOR
-ses
-xZk
+ebh
+bwP
+asI
 adm
 afd
 afd
@@ -92357,12 +92678,12 @@ aaa
 aaa
 alc
 alc
-xZk
-xRT
-xRT
-xRT
-ses
-xZk
+asI
+aod
+aod
+aod
+bwP
+asI
 adm
 adm
 adm
@@ -92616,10 +92937,10 @@ aaa
 aaa
 aaa
 aaa
-xRT
+aod
 fQx
-pZu
-xZk
+ahp
+asI
 adm
 adm
 adm
@@ -92627,14 +92948,14 @@ adm
 adm
 aod
 aod
-dqm
+bwP
 dgU
 aYg
 aqC
 ary
-asy
+sPE
 atA
-auE
+gwq
 avP
 cSu
 axZ
@@ -92873,22 +93194,22 @@ aaa
 aaa
 aaa
 aaa
-xRT
+aod
 vls
 hVR
-xRT
-xRT
-xRT
+aod
+aod
+aod
 adm
 adm
 adm
 aod
 dgU
-dqm
+bwP
 dgU
 adm
 aqD
-asy
+sPE
 aOh
 aai
 aQy
@@ -92958,11 +93279,11 @@ aaa
 aaa
 aaa
 aFt
-cXh
+biL
 cWD
 cXX
 ayw
-cXh
+biL
 aIk
 aaa
 aaa
@@ -93130,18 +93451,18 @@ aaa
 aaa
 aaa
 aaa
-uuF
-vOR
+bwO
+dgU
 acH
 eIm
 ecv
 vyJ
 doz
 arR
-cKW
-cKW
-cKW
-dpP
+eIm
+eIm
+eIm
+afS
 dgU
 dhR
 aqC
@@ -93387,12 +93708,12 @@ aaa
 aaa
 aaa
 aaa
-uuF
-vsE
+bwO
+lZB
 vtB
-vsE
+lZB
 svz
-xyk
+dho
 aln
 anW
 aDr
@@ -93644,12 +93965,12 @@ aaa
 aaa
 aaa
 aaa
-uuF
-vsE
+bwO
+lZB
 pZu
 oRA
-vsE
-xRT
+lZB
+aod
 aod
 aod
 adm
@@ -93901,12 +94222,12 @@ aaa
 aaa
 aaa
 aaa
-uuF
-vOR
+bwO
+dgU
 pZu
 kUG
-vOR
-xZk
+dgU
+asI
 adm
 adm
 aod
@@ -93986,11 +94307,11 @@ aaa
 aaa
 aaa
 aFt
-cXh
+biL
 cWD
 cXX
-cWP
-cXh
+ayw
+biL
 aIk
 aaa
 aaa
@@ -94158,12 +94479,12 @@ aaa
 aaa
 aaa
 aaa
-uuF
-vOR
-ses
+bwO
+dgU
+dqm
 lDf
-xZk
-xZk
+asI
+asI
 adm
 adm
 aod
@@ -94256,7 +94577,7 @@ aaa
 aaa
 aaa
 aZO
-dQn
+aiL
 aZO
 aZO
 aZO
@@ -94415,11 +94736,11 @@ aaa
 aaa
 aaa
 aaa
-xRT
+aod
 gdS
 pZu
 qia
-xZk
+asI
 adm
 adm
 adm
@@ -94544,7 +94865,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaf
 aaa
 aaa
 cFp
@@ -94672,11 +94993,11 @@ aaa
 aaa
 aaa
 aaa
-xRT
+aod
 svC
 pZu
-vsE
-xRT
+lZB
+aod
 adm
 adm
 adm
@@ -94799,9 +95120,9 @@ aaa
 aaa
 aaa
 aaa
-qoZ
 aaa
-aaf
+aaa
+aaa
 aaa
 aaa
 cFp
@@ -94818,11 +95139,11 @@ cFp
 aaa
 aZO
 aZO
-ceH
-ceH
-ceH
-ceH
-ceH
+aGD
+aGD
+aGD
+aGD
+aGD
 aZO
 aZO
 ceW
@@ -94929,11 +95250,11 @@ aaa
 aaa
 aaa
 aaa
-xRT
-xRT
+aod
+aod
 abw
-xRT
-xRT
+aod
+aod
 adm
 adm
 adm
@@ -95053,14 +95374,14 @@ aZO
 aZO
 aZO
 aaa
+aZO
+aZO
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+blu
+blu
+aaf
 cFp
 cFp
 cFp
@@ -95075,11 +95396,11 @@ cFp
 aaa
 aZO
 aZO
-ceH
+aGD
 cfd
 cfB
 cgh
-ceH
+aGD
 aZO
 aZO
 ceW
@@ -95187,9 +95508,9 @@ aaa
 aaa
 aaa
 aaa
-xRT
-ses
-xRT
+aod
+dqm
+aod
 adm
 adm
 adm
@@ -95271,11 +95592,11 @@ aaa
 aaa
 aaa
 aFt
-cXh
+biL
 cWC
 cXX
 cWK
-cXh
+biL
 aIk
 aaa
 aaa
@@ -95313,12 +95634,12 @@ aZO
 aZO
 aZO
 aaa
-aaa
 aaf
 blu
 blu
+blu
+blu
 aaf
-cFp
 cFp
 cFp
 cFp
@@ -95332,11 +95653,11 @@ cFp
 aaa
 aaa
 aZO
-ceH
+aGD
 cfe
 cfB
 cgi
-ceH
+aGD
 aZO
 aZO
 ceW
@@ -95443,10 +95764,10 @@ aaa
 aaa
 aaa
 aaa
-xRT
-xZk
-ses
-xZk
+aod
+asI
+dqm
+asI
 adm
 adm
 adm
@@ -95567,34 +95888,34 @@ aZO
 aZO
 aZO
 aZO
+cUy
+cUy
+cUy
+cUz
+cUz
+cUz
+cUy
+cUy
+blu
+aaa
+aaa
+blu
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aZO
-aZO
-aaa
-aaf
-blu
-blu
-blu
-blu
-aaf
-aaa
-aaa
-blu
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aZO
-ceH
+aGD
 cff
 cfC
 cgj
-ceH
-ceH
+aGD
+aGD
 aZO
 ceW
 cjr
@@ -95700,10 +96021,10 @@ aaa
 aaa
 aaa
 aaa
-xRT
+aod
 tNh
-ses
-xZk
+dqm
+asI
 adm
 adm
 adm
@@ -95824,14 +96145,15 @@ aZO
 aZO
 aZO
 aZO
-cUy
-cUy
-cUy
 cUz
-cUz
+fRb
+sOR
+hVi
+qoZ
+pFt
+cIu
 cUy
-cUy
-blu
+aaf
 aaf
 aaa
 aaa
@@ -95844,14 +96166,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aZO
-ceH
-ceH
+aGD
+aGD
 cfD
 qOD
 adn
-ceH
+aGD
 aZO
 aZO
 abC
@@ -95957,10 +96278,10 @@ aaa
 aaa
 aaa
 aaa
-xRT
+aod
 cHI
-oOd
-xZk
+dpP
+asI
 adm
 adm
 adm
@@ -96083,10 +96404,11 @@ bmL
 dew
 cUz
 fRb
-sOR
-hVi
-oPd
-cIu
+bJK
+sFG
+pjt
+vGI
+vgL
 cUy
 aaf
 aaa
@@ -96102,13 +96424,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aZO
-ceH
+aGD
 cfE
 cgl
 cgR
-ceH
+aGD
 aZO
 aZO
 aaa
@@ -96214,10 +96535,10 @@ aaa
 aaa
 aaa
 aaa
-xRT
-amn
-xRT
-xZk
+aod
+pqz
+aod
+asI
 adm
 adm
 adm
@@ -96340,9 +96661,10 @@ rnU
 bZv
 cUz
 cUW
-bJK
-sFG
+mvr
+vGI
 jjJ
+cUW
 dCx
 cUy
 iwP
@@ -96354,18 +96676,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
 alc
 alc
 alc
 alc
 alc
-ceH
-ceH
-ceH
+aGD
+aGD
+aGD
 cgl
 cgS
-ceH
+aGD
 aZO
 aZO
 aaa
@@ -96471,9 +96792,9 @@ aaa
 aaa
 aaa
 aaa
-xRT
+aod
 abW
-xRT
+aod
 aZO
 aZO
 adm
@@ -96556,11 +96877,11 @@ aiL
 aiL
 aaa
 pnH
-cXh
+biL
 cWC
 cXX
 ayw
-cXh
+biL
 bVq
 aZO
 aZO
@@ -96600,7 +96921,8 @@ cIs
 cYB
 aXD
 pjt
-ktP
+vGI
+xyk
 cVb
 myt
 cKs
@@ -96609,7 +96931,6 @@ cKs
 cKs
 xRL
 aco
-aaa
 aaa
 alc
 alc
@@ -96620,18 +96941,18 @@ pUZ
 ceI
 cfg
 cfF
-cgk
-ceH
-ceH
+odW
+aGD
+aGD
 aZO
 aZO
 aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aZO
@@ -96855,8 +97176,9 @@ cUn
 nVv
 kYJ
 pXj
-nGt
+pjt
 cef
+myn
 cJi
 cVc
 ozq
@@ -96869,16 +97191,15 @@ acQ
 aaa
 aaa
 aaa
-aaa
 alc
 alc
 alc
 alc
-ceH
-ceH
-ceH
-ceH
-ceH
+aGD
+aGD
+aGD
+aGD
+aGD
 aZO
 aZO
 aZO
@@ -96886,9 +97207,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aZO
@@ -97114,6 +97435,7 @@ qTW
 cYB
 vGI
 odT
+odT
 led
 jOh
 jmk
@@ -97124,7 +97446,6 @@ cVc
 cVu
 acQ
 abR
-aaa
 aaa
 aaa
 aaa
@@ -97143,9 +97464,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -97371,6 +97692,7 @@ cUI
 cFB
 pIG
 hGW
+pjt
 cGM
 cVe
 uxv
@@ -97379,7 +97701,6 @@ cVo
 cVr
 cVs
 cVv
-aaa
 aaa
 aaa
 aaa
@@ -97400,9 +97721,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -97582,15 +97903,15 @@ aae
 aae
 aae
 aae
-aYJ
+bxW
 bmu
-aYJ
+bxW
 cIK
 aYM
 brQ
-aYJ
-buL
-aYJ
+bxW
+bmJ
+bxW
 aZO
 bIo
 bmL
@@ -97628,6 +97949,7 @@ cUJ
 bYc
 rYM
 wgC
+wgC
 kyo
 cVf
 sIm
@@ -97655,11 +97977,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
 pUZ
 cXh
 cXj
-cXX
+oHu
 cXn
 cXh
 aaa
@@ -97839,15 +98160,15 @@ aae
 aae
 aae
 aae
-aYJ
+bxW
 bmv
-aYJ
+bxW
 cJf
 bhT
 bQo
-aYJ
+bxW
 cFs
-aYJ
+bxW
 aZO
 bIo
 bIo
@@ -97885,8 +98206,9 @@ cGN
 cVc
 oNB
 cVc
+cVc
 fpY
-fpY
+eQv
 syS
 cVc
 mEZ
@@ -97912,11 +98234,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -98032,7 +98353,7 @@ arP
 asE
 atM
 auL
-avZ
+aEU
 aDs
 ayj
 azF
@@ -98093,21 +98414,21 @@ aXP
 aYE
 cIy
 aae
-aYJ
-aYJ
-aYJ
-aYJ
+bxW
+bxW
+bxW
+bxW
 bmw
-aYJ
+bxW
 cJf
 bhT
 bQo
-aYJ
-cfX
-aYJ
-aYJ
-aYJ
-aYJ
+bxW
+ktP
+bxW
+bxW
+bxW
+bxW
 knE
 cIC
 bCH
@@ -98171,9 +98492,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -98350,21 +98671,21 @@ beS
 cFi
 cIy
 aae
-aYJ
+bxW
 bao
 bao
 blg
 bmx
-aYJ
+bxW
 cJf
 bhT
 bRg
-aYJ
+bxW
 buN
 bwh
 bHO
 byt
-aYJ
+bxW
 kKC
 cIC
 bIo
@@ -98428,9 +98749,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -98607,16 +98928,16 @@ cIy
 cIy
 cIy
 aae
-aYJ
+bxW
 baQ
 baQ
 blh
 bHO
-aYJ
+bxW
 boW
 bhT
 brS
-aYJ
+bxW
 cFw
 cRn
 cRn
@@ -98685,9 +99006,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -98864,7 +99185,7 @@ beT
 bfV
 cIy
 aaf
-aYJ
+bxW
 baQ
 baQ
 blh
@@ -98873,7 +99194,7 @@ bdu
 cJf
 bhT
 bQo
-aYJ
+bxW
 buM
 baQ
 baQ
@@ -98944,7 +99265,7 @@ aaa
 pUZ
 cXh
 cJC
-cXX
+oHu
 coU
 cXh
 alc
@@ -99121,12 +99442,12 @@ bbN
 bfW
 cIy
 aaf
-aYJ
+bxW
 baQ
 baQ
 blh
 baM
-aYJ
+bxW
 cJf
 awy
 brT
@@ -99134,11 +99455,11 @@ btn
 buO
 baQ
 cOX
-biL
-biL
+bpM
+bpM
 bAD
-bwi
-bwi
+vCm
+vCm
 bDR
 bFe
 bGN
@@ -99199,9 +99520,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -99378,20 +99699,20 @@ bcA
 bfX
 cIy
 aaf
-aYJ
+bxW
 bcH
 bkz
 bli
 cOX
-aYJ
+bxW
 boX
 bqm
 brU
-aYJ
+bxW
 rjQ
-bwi
-bwi
-bwi
+vCm
+vCm
+vCm
 bzs
 bAE
 bBI
@@ -99456,9 +99777,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -99634,19 +99955,19 @@ bee
 beU
 bfY
 cIy
-aYJ
-aYJ
-aYJ
-aYJ
+bxW
+bxW
+bxW
+bxW
 blj
-aYJ
-aYJ
+bxW
+bxW
 cJf
 bhT
 brV
-aYJ
-aYJ
-bwi
+bxW
+bxW
+vCm
 bxt
 bAF
 tWm
@@ -99713,9 +100034,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -99907,10 +100228,10 @@ jjn
 bxu
 byw
 bzu
-uhX
-uhX
+uqX
+uqX
 bCJ
-uhX
+uqX
 lWb
 bGQ
 bIq
@@ -99970,9 +100291,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 alc
@@ -100229,7 +100550,7 @@ aaa
 pUZ
 cXh
 cXj
-cXX
+oHu
 aZQ
 cXh
 aaa
@@ -100417,7 +100738,7 @@ bqq
 brY
 cYb
 buR
-bwl
+oyc
 bxw
 byy
 bzw
@@ -100484,9 +100805,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -100741,9 +101062,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -100914,7 +101235,7 @@ baK
 bbq
 bbP
 aZK
-aYJ
+bxW
 bei
 cIt
 brR
@@ -100998,9 +101319,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -101034,8 +101355,8 @@ aaa
 abR
 oMy
 nmu
-upG
-dxN
+aeD
+atS
 wDX
 abR
 aaa
@@ -101257,7 +101578,7 @@ aaa
 pUZ
 cXh
 cJC
-cXX
+oHu
 cXo
 cXh
 aaa
@@ -101291,8 +101612,8 @@ aaa
 abR
 oMy
 ajf
-upG
-upG
+uTG
+aeD
 wDX
 sFZ
 osh
@@ -101422,13 +101743,13 @@ aiL
 aZO
 aZO
 aZO
-aYJ
-aYJ
-aYJ
-aYJ
+bxW
+bxW
+bxW
+bxW
 bbR
-aYJ
-aYJ
+bxW
+bxW
 bEd
 beX
 inS
@@ -101512,11 +101833,11 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
-cme
+buH
 aaa
 aaa
 hqK
@@ -101548,9 +101869,9 @@ aaa
 abR
 oMy
 ajf
-upG
-upG
-ryA
+aeD
+aeD
+aFz
 tDi
 ryA
 aaa
@@ -101679,13 +102000,13 @@ aiL
 aiL
 aiL
 aZO
-aYJ
+bxW
 bai
 tVL
 baQ
 bbS
 baQ
-aYJ
+bxW
 aZl
 cIt
 cWL
@@ -101769,9 +102090,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -101805,9 +102126,9 @@ aaa
 abR
 wDX
 iWG
-upG
-upG
-ryA
+aeD
+aeD
+aFz
 eGM
 ryA
 cEl
@@ -101934,15 +102255,15 @@ aaa
 aaa
 aiL
 aiL
-aYJ
-aYJ
-aYJ
+bxW
+bxW
+bxW
 baj
 baQ
 baQ
 cRn
 baQ
-aYJ
+bxW
 aZl
 cIt
 cWL
@@ -102026,9 +102347,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -102063,7 +102384,7 @@ abR
 oMy
 ajf
 dxN
-upG
+aeD
 wDX
 osh
 osh
@@ -102199,7 +102520,7 @@ bak
 bbs
 bbU
 baQ
-aYJ
+bxW
 bek
 cIt
 cWL
@@ -102285,7 +102606,7 @@ aaa
 pUZ
 cXh
 cXj
-cXX
+oHu
 coV
 cXh
 alc
@@ -102320,7 +102641,7 @@ abR
 oMy
 ajf
 upG
-upG
+aeD
 xsS
 wDX
 aaa
@@ -102433,30 +102754,30 @@ aNX
 xXK
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
-cXh
-xXK
-xXK
-xXK
-cXh
+biL
 xXK
 xXK
 xXK
-aYJ
-aYJ
-aYJ
-aYJ
-aYJ
-aYJ
+biL
+xXK
+xXK
+xXK
+bxW
+bxW
+bxW
+bxW
+bxW
+bxW
 bbV
-aYJ
-aYJ
+bxW
+bxW
 aZl
 cIt
 cWL
@@ -102540,9 +102861,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cYh
+buH
+oHu
+jrc
 aZQ
 cpC
 aaa
@@ -102576,8 +102897,8 @@ aaa
 abR
 oMy
 wnl
-upG
-upG
+aeD
+aeD
 dXs
 osh
 aaa
@@ -102797,9 +103118,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -103054,11 +103375,11 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
-cme
+buH
 aaa
 aaa
 hqK
@@ -103313,7 +103634,7 @@ aaa
 pUZ
 cXh
 cJC
-cXX
+oHu
 aZQ
 cXh
 alc
@@ -103461,30 +103782,30 @@ aNX
 xXK
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
-cXh
-xXK
-xXK
-xXK
-cXh
+biL
 xXK
 xXK
 xXK
-aYJ
-aYJ
-aYJ
-aYJ
-aYJ
-aYJ
-aYJ
-aYJ
-aYJ
+biL
+xXK
+xXK
+xXK
+bxW
+bxW
+bxW
+bxW
+bxW
+bxW
+bxW
+bxW
+bxW
 bep
 cIt
 cWM
@@ -103568,9 +103889,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -103741,7 +104062,7 @@ baQ
 bbt
 baM
 tVL
-aYJ
+bxW
 bep
 cIt
 cWM
@@ -103825,9 +104146,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -103990,9 +104311,9 @@ aaa
 aaa
 aaa
 aaa
-aYJ
-aYJ
-aYJ
+bxW
+bxW
+bxW
 ban
 bbu
 bbu
@@ -104082,9 +104403,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -104249,13 +104570,13 @@ aaa
 aaa
 aiL
 aZO
-aYJ
+bxW
 bao
 cRn
 baQ
 baQ
 bcG
-aYJ
+bxW
 bep
 cIt
 cWM
@@ -104341,7 +104662,7 @@ aaa
 pUZ
 cXh
 cXj
-cXX
+oHu
 cXq
 cXh
 aaa
@@ -104506,13 +104827,13 @@ cFp
 aaa
 aiL
 aZO
-aYJ
+bxW
 bao
 baR
 bbv
 bHO
 bcH
-aYJ
+bxW
 dTE
 tan
 njK
@@ -104596,9 +104917,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -104763,12 +105084,12 @@ aaa
 aaa
 aZO
 aZO
-aYJ
-aYJ
-aYJ
-aYJ
-aYJ
-aYJ
+bxW
+bxW
+bxW
+bxW
+bxW
+bxW
 bdu
 bep
 cIt
@@ -104853,9 +105174,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -105110,9 +105431,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -105367,9 +105688,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 alc
@@ -105626,7 +105947,7 @@ aaa
 pUZ
 cXh
 cJC
-cXX
+oHu
 aZQ
 cXh
 aaa
@@ -105881,9 +106202,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -106138,9 +106459,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -106317,17 +106638,17 @@ bev
 bgk
 bev
 baS
-biL
-aYJ
-aYJ
+bpM
+bxW
+bxW
 blv
-aYJ
-aYJ
+bxW
+bxW
 bpl
 cIo
 bsh
-aYJ
-aYJ
+bxW
+bxW
 bwi
 bxI
 byJ
@@ -106395,9 +106716,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 alc
@@ -106574,16 +106895,16 @@ bfh
 bgl
 bhg
 bhV
-biL
+bpM
 bjF
 bkF
 blw
 baM
-aYJ
+bxW
 bpm
 bqF
 bsi
-aYJ
+bxW
 cUl
 bwi
 bwi
@@ -106652,9 +106973,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -106831,12 +107152,12 @@ bfk
 bgm
 bbZ
 bhW
-biL
+bpM
 baQ
 baQ
 buN
 baM
-aYJ
+bxW
 cYb
 cIN
 bsj
@@ -106865,7 +107186,7 @@ bZN
 aXR
 aXR
 cUe
-bdx
+cYu
 mIU
 cUa
 aFe
@@ -106911,7 +107232,7 @@ aaa
 pUZ
 cXh
 cXj
-cXX
+oHu
 cXr
 cXh
 aaa
@@ -107088,12 +107409,12 @@ bfj
 bTe
 bhi
 bhX
-biL
+bpM
 bbv
 baQ
 buN
 baQ
-aYJ
+bxW
 cYb
 cIN
 cUd
@@ -107166,9 +107487,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -107345,7 +107666,7 @@ bfk
 bgo
 bhj
 bhY
-biL
+bpM
 baQ
 baQ
 buN
@@ -107354,7 +107675,7 @@ bdu
 cYb
 cIN
 bsk
-aYJ
+bxW
 bvj
 bAL
 bAL
@@ -107423,9 +107744,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -107602,16 +107923,16 @@ bfl
 bgp
 bhk
 bhZ
-biL
+bpM
 bao
 bao
 blA
 bam
-aYJ
+bxW
 cYb
 cIN
 pAl
-aYJ
+bxW
 bvk
 bwy
 bAL
@@ -107680,9 +108001,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -107859,16 +108180,16 @@ baS
 baS
 baS
 baS
-biL
-aYJ
-aYJ
-aYJ
+bpM
+bxW
+bxW
+bxW
 bmJ
-aYJ
+bxW
 cYb
 cIN
 cUd
-aYJ
+bxW
 bvl
 cUa
 bAL
@@ -107937,9 +108258,9 @@ aaa
 aaa
 aaa
 pUZ
-cme
-cXX
-cXX
+buH
+oHu
+oHu
 aZQ
 cpC
 aaa
@@ -108119,13 +108440,13 @@ aZO
 aZO
 aZO
 aZO
-aYJ
+bxW
 bmK
-aYJ
+bxW
 cYb
 cIN
 cUd
-aYJ
+bxW
 bvm
 aFe
 bQN
@@ -108376,13 +108697,13 @@ aZO
 aZO
 aZO
 aiL
-aYJ
-cfX
-aYJ
+bxW
+ktP
+bxW
 aAn
 cIO
 bsm
-aYJ
+bxW
 cfY
 cUa
 bZN
@@ -108951,7 +109272,7 @@ aaa
 aaa
 aaa
 cdt
-cJw
+aTg
 cdt
 aiL
 aiL
@@ -109406,11 +109727,11 @@ aaa
 alc
 aaa
 bVq
-cXh
-cXj
+biL
+nuh
 cXp
 cWO
-cXh
+biL
 pnH
 aZO
 aZO
@@ -109465,7 +109786,7 @@ aaf
 aiL
 cdu
 cdD
-aRH
+wPU
 cei
 cdv
 uUf
@@ -109979,7 +110300,7 @@ aiL
 aiL
 cdu
 cdF
-cyu
+bbn
 cek
 cdu
 cyu
@@ -110260,13 +110581,13 @@ cmf
 cmf
 cmf
 cmf
-cup
+aOI
 cmf
 cmf
 cmf
 cmf
 cmf
-cup
+aOI
 cmf
 cmf
 cmf
@@ -110691,11 +111012,11 @@ aaa
 alc
 aaa
 bVq
-cXh
-cJC
+biL
+btW
 cXp
-cWP
-cXh
+ayw
+biL
 aFt
 aaa
 aaa
@@ -111105,8 +111426,8 @@ abO
 aaE
 aaS
 cEn
-aeC
-aeC
+bBs
+bBs
 abZ
 acn
 aaF
@@ -111126,11 +111447,11 @@ ahA
 aie
 adq
 ajD
-ako
-ako
-ako
-ako
-ako
+aos
+aos
+aos
+aos
+aos
 aaf
 aaf
 aaa
@@ -111363,8 +111684,8 @@ uSU
 aaT
 wMJ
 aby
-aeC
-aeC
+bBs
+bBs
 acu
 acv
 aax
@@ -111383,13 +111704,13 @@ ahB
 aif
 adq
 ajE
-odW
-odW
 qPP
-amD
-ako
-ako
-ako
+qPP
+qPP
+qPP
+aos
+aos
+aos
 cFp
 cFp
 cFp
@@ -111621,8 +111942,8 @@ aeC
 abO
 vAX
 vAX
-aeC
-aeC
+bBs
+bBs
 acv
 aax
 aau
@@ -111805,16 +112126,16 @@ aaa
 aaa
 aaa
 cmf
-cup
-cup
+aOI
+aOI
 cmf
 aaa
 aaa
 aaa
 aaa
 cmf
-cup
-cup
+aOI
+aOI
 cmf
 aaa
 aaa
@@ -111879,7 +112200,7 @@ abn
 aaS
 abP
 aax
-aeC
+bBs
 acw
 aax
 acO
@@ -111896,14 +112217,14 @@ agO
 adq
 adq
 adq
-noa
+kGq
 akr
-ako
-ako
-ako
-ako
-ako
-ako
+aos
+aos
+aos
+aos
+aos
+aos
 aos
 dzg
 dzg
@@ -111976,11 +112297,11 @@ aaa
 alc
 aaa
 bVq
-cXh
-cXj
+biL
+nuh
 cXp
 cWQ
-cXh
+biL
 aFt
 aaa
 aaa
@@ -112141,12 +112462,12 @@ acx
 abZ
 abZ
 aal
-cxD
-cxD
-cxD
-cxD
-cxD
-cxD
+dvd
+iNd
+iNd
+iNd
+iNd
+iNd
 afW
 hYi
 agP
@@ -112400,7 +112721,7 @@ afP
 acR
 adg
 adg
-adg
+iKZ
 aef
 adg
 adg
@@ -112489,7 +112810,7 @@ aaa
 aaa
 alc
 aaa
-aFz
+bVq
 cme
 cXX
 cXp
@@ -112662,7 +112983,7 @@ cxD
 cxD
 cxD
 afW
-afS
+hYi
 agR
 ahD
 aij
@@ -112907,7 +113228,7 @@ abo
 aaS
 abP
 aax
-aeC
+bBs
 acA
 aax
 qsA
@@ -112924,14 +113245,14 @@ agS
 bhv
 bhv
 bhv
-noa
+kGq
 akv
-ako
-ako
-ako
-ako
-ako
-ako
+aos
+aos
+aos
+aos
+aos
+aos
 aos
 dzg
 dzg
@@ -113163,8 +113484,8 @@ aeC
 abO
 vAX
 vAX
-aeC
-aeC
+bBs
+bBs
 acB
 aax
 gWX
@@ -113419,11 +113740,11 @@ uSU
 aaT
 wMJ
 aby
-aeC
-aeC
+bBs
+bBs
 acC
-acB
-aax
+ggW
+wMJ
 vAX
 nSe
 ade
@@ -113434,18 +113755,18 @@ akp
 akp
 afW
 afV
-fOI
+agR
 cKB
 qgd
 bhv
 ajE
-amD
-amD
-amD
-amD
-ako
-ako
-ako
+qPP
+qPP
+qPP
+qPP
+aos
+aos
+aos
 alc
 aaa
 aaa
@@ -113675,8 +113996,8 @@ abO
 aaE
 aaS
 cEn
-aeC
-aeC
+bBs
+bBs
 acc
 acp
 aaF
@@ -113696,11 +114017,11 @@ izF
 bhv
 bhv
 ajD
-ako
-ako
-ako
-ako
-ako
+aos
+aos
+aos
+aos
+aos
 aaf
 aaa
 alc
@@ -114039,7 +114360,7 @@ rEt
 aZq
 bvt
 bwA
-bxM
+npM
 aZq
 aZO
 aZO
@@ -114294,8 +114615,8 @@ cXM
 taY
 rEt
 aZq
-ccB
-bwB
+bdx
+wiv
 bXT
 aZq
 aZO
@@ -114339,9 +114660,9 @@ alc
 alc
 aZN
 aZO
-aZq
-aZq
-aZq
+cmf
+cmf
+cmf
 aJS
 aJS
 aJS
@@ -114551,9 +114872,9 @@ cXM
 taY
 rEt
 aZq
-ccB
-bwC
-bxO
+bdx
+jDR
+hDf
 aZq
 aZO
 aZO
@@ -114596,23 +114917,23 @@ aaa
 aaa
 aaa
 aZO
-aZq
+cmf
 ccA
 ccH
 ccP
 cde
-bxM
-aZq
+rtp
+cmf
 aZO
 aZO
 aZO
 aZO
 aZO
 aZO
-aZq
-aZq
-aZq
-aZq
+cmf
+cmf
+cmf
+cmf
 owx
 uUf
 jyC
@@ -114632,16 +114953,16 @@ csG
 csG
 csG
 cmf
-cup
-cup
+aOI
+aOI
 cmf
 csG
 csG
 csG
 csG
 cmf
-cup
-cup
+aOI
+aOI
 cmf
 aaa
 aaa
@@ -114808,9 +115129,9 @@ cXM
 taY
 rEt
 aZq
-ccB
-bwC
-bxP
+bdx
+jDR
+qXh
 aZq
 aZq
 aZq
@@ -114851,25 +115172,25 @@ aaa
 aaa
 aaa
 aaa
-aZq
-aZq
-aZq
-ccB
-bwC
-dhC
+cmf
+cmf
+cmf
+aZR
+kGS
+kts
 cdf
 cdk
-aZq
-aZq
+cmf
+cmf
 aZO
 aZO
 aZO
 aZO
 aZO
-aZq
-bKV
-bMB
-aZq
+cmf
+qLR
+cuo
+cmf
 owx
 xWP
 uUf
@@ -115084,7 +115405,7 @@ aem
 bOI
 cNr
 bQP
-bPO
+hGF
 bSA
 bSA
 bSA
@@ -115117,16 +115438,16 @@ ccR
 cdg
 cdl
 cdo
-aZq
+cmf
 aZO
 aZO
 aZO
 aZO
 aZO
-aZq
-bMB
+cmf
+cuo
 cFK
-aZq
+cmf
 owx
 owx
 guA
@@ -115283,11 +115604,11 @@ aaa
 vDb
 aaa
 aaa
-aZR
-aZR
-aZR
-aZR
-aZR
+aWQ
+aWQ
+aWQ
+aWQ
+aWQ
 vSV
 aWQ
 aWQ
@@ -115350,43 +115671,43 @@ xXK
 xXK
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
 xXK
 xXK
-aZq
-aZq
-aZq
-aZq
-aZq
-bcg
-aZq
-aZq
+cmf
+cmf
+cmf
+cmf
+cmf
+cpD
+cmf
+cmf
 cdp
-aZq
-aZq
-aZq
-aZq
-aZq
-aZq
-aZq
+cmf
+cmf
+cmf
+cmf
+cmf
+cmf
+cmf
 cFJ
-aZq
-aZq
-aZq
-aZq
-aZq
+cmf
+cmf
+cmf
+cmf
+cmf
 aWX
 vZq
 clK
@@ -115568,7 +115889,7 @@ bMB
 aZq
 aUC
 ujO
-ujO
+mTO
 bjG
 dyY
 dzm
@@ -115584,7 +115905,7 @@ bMw
 ujO
 byM
 gQp
-ujO
+mTO
 ujO
 ujO
 ujO
@@ -115622,14 +115943,14 @@ cXX
 cXX
 cXX
 cXX
-aum
-bso
-bso
-bSB
-bso
-bso
-bso
-cdm
+vLF
+eBh
+eBh
+vvP
+eBh
+eBh
+eBh
+rVe
 cdq
 cdw
 ckW
@@ -115797,11 +116118,11 @@ aZO
 aaa
 aaa
 aaa
-aZR
-aZR
-aZR
-aZR
-aZR
+aWQ
+aWQ
+aWQ
+aWQ
+aWQ
 vTT
 aWQ
 aWQ
@@ -115820,19 +116141,19 @@ aZO
 aZO
 aZq
 brq
-bMB
+avZ
 bza
 bBr
-gvh
+aNH
 cFl
-dyZ
+ckK
 bjH
 dyZ
 dyZ
 blG
-dyZ
+daO
 aTr
-dyZ
+bTV
 bgO
 vmK
 dyZ
@@ -115879,35 +116200,35 @@ cIm
 cIm
 cIm
 cIm
-cir
-cus
-ccu
-cus
+qEE
+cpS
+noa
+cpS
 bnZ
-cus
-cus
-ctZ
+cpS
+cpS
+qYq
 aRe
-cus
-cus
-cus
+cpS
+cpS
+cpS
 cwa
-cus
+cpS
 cxF
-cus
-cus
-cus
-cus
-cus
-cus
-cGP
+cpS
+cpS
+cpS
+cpS
+cpS
+cpS
+fOI
 nyc
-cus
+cpS
 aXr
 cmx
-cus
-cus
-cus
+cpS
+cpS
+cpS
 cpS
 cqX
 crL
@@ -116077,8 +116398,8 @@ aZO
 aZO
 aZq
 brr
-cYq
-jry
+ijL
+spv
 aZq
 gvh
 onp
@@ -116126,7 +116447,7 @@ ayw
 ayw
 ayw
 ayw
-cXa
+ayw
 ayw
 ayw
 ayw
@@ -116136,10 +116457,10 @@ ayw
 ayw
 ayw
 ayw
-cXd
-cXe
-cXe
-cXe
+dQn
+cYe
+cYe
+cYe
 ccJ
 ccS
 aQZ
@@ -116378,50 +116699,50 @@ ccg
 ccg
 ccg
 ccg
-cXh
+biL
 ccg
 ccg
 ccg
 ccg
-cXh
+biL
 ccg
 ccg
 ccg
 ccg
-cXh
+biL
 ccg
 ccg
 ccg
 ccg
-aZq
-aZq
-aZq
-aZq
-aZq
-aZq
-aZq
-aZq
-aZq
-cdz
-aZq
-aZq
-aZq
-aZq
-aZq
-aZq
-aZq
-aZq
-bcg
-aZq
-aZq
-aZq
+cmf
+cmf
+cmf
+cmf
+cmf
+cmf
+cmf
+cmf
+cmf
+hKo
+cmf
+cmf
+cmf
+cmf
+cmf
+cmf
+cmf
+cmf
+cpD
+cmf
+cmf
+cmf
 oXY
 oXY
-aZq
+cmf
 wLz
 hrS
 wLz
-aZq
+cmf
 cpU
 cqZ
 crS
@@ -116626,7 +116947,7 @@ ccK
 bOL
 ccr
 bQR
-ccD
+cfW
 cco
 cco
 cco
@@ -116651,16 +116972,16 @@ akk
 akk
 siO
 cco
-ccr
+saV
 ccv
-ccD
-ccK
-ccK
-ccK
-ccK
-ccK
+aNo
+ako
+ako
+ako
+ako
+ako
 cdA
-aZq
+cmf
 aZO
 aZO
 aZO
@@ -116808,13 +117129,13 @@ aZN
 aaa
 aaa
 aZq
-aNo
+bvq
 aZq
 asd
 atJ
 aum
 aZq
-aTg
+bvq
 aZq
 aiL
 aiL
@@ -116908,16 +117229,16 @@ aaa
 aaa
 aaa
 aaa
-aZq
-aZq
-aZq
-bMB
-bMB
-bMB
-bMB
-aZq
-aZq
-aZq
+cmf
+cmf
+cmf
+cuo
+cuo
+cuo
+cuo
+cmf
+cmf
+cmf
 aZO
 aZO
 aZO
@@ -117131,7 +117452,7 @@ fxt
 dBq
 bEu
 bFI
-bDl
+lxV
 bIN
 bCg
 bMB
@@ -117167,12 +117488,12 @@ aaa
 aZO
 aZO
 aZO
-aZq
-bcc
-bNH
-bdF
-beE
-aZq
+cmf
+fHO
+asF
+xhB
+xUQ
+cmf
 aZO
 aZO
 aZO
@@ -117326,7 +117647,7 @@ aTi
 aZq
 sCv
 dyZ
-aRG
+gTX
 aZq
 aTi
 aZq
@@ -117367,7 +117688,7 @@ beA
 bCh
 rSj
 dyZ
-aFh
+chj
 dzy
 bjK
 pxU
@@ -117424,12 +117745,12 @@ aaa
 aZO
 aZO
 aZO
-aZq
-aZq
-aZq
-aZq
-aZq
-aZq
+cmf
+cmf
+cmf
+cmf
+cmf
+cmf
 aZO
 aZO
 aZO
@@ -117624,7 +117945,7 @@ beA
 bCe
 rSj
 dyZ
-aFh
+chj
 dzy
 cOu
 cOF
@@ -117716,16 +118037,16 @@ aiL
 aiL
 aaa
 cmf
-cup
-cup
+aOI
+aOI
 cmf
 aaa
 aaa
 aaa
 aaa
 cmf
-cup
-cup
+aOI
+aOI
 cmf
 aaa
 aaa
@@ -117881,7 +118202,7 @@ beA
 bCm
 rSj
 dza
-aFh
+chj
 cOh
 cOu
 cOG
@@ -118332,12 +118653,12 @@ jPx
 cTq
 aJu
 arT
-axf
-ayJ
-ayJ
+oYK
+efr
+efr
 awt
-asV
-asV
+iOW
+iOW
 azY
 aJu
 arW
@@ -118592,8 +118913,8 @@ arU
 asW
 atY
 pRt
-asV
-axf
+iOW
+oYK
 asV
 azZ
 aJu
@@ -118911,10 +119232,10 @@ rSj
 taY
 bif
 cOj
-biP
-biP
-biP
-biP
+kNu
+kNu
+kNu
+kNu
 boe
 oeX
 dAc
@@ -118936,7 +119257,7 @@ bCg
 cFz
 bLb
 bLb
-vGJ
+foH
 vGJ
 bBm
 bBm
@@ -119167,11 +119488,11 @@ aZq
 rSj
 taY
 aFh
-biP
+kNu
 bjN
 bkJ
 blJ
-bnc
+jMA
 bof
 bpB
 bqR
@@ -119424,8 +119745,8 @@ bfo
 bgx
 bhr
 blH
-biP
-bjO
+wBa
+qEi
 wGW
 blK
 bnb
@@ -119450,7 +119771,7 @@ bJZ
 bLc
 bMH
 bLb
-vGJ
+foH
 xbV
 bBj
 bBm
@@ -119621,7 +119942,7 @@ cGh
 aqZ
 avj
 anu
-anu
+ija
 ayL
 aAc
 arf
@@ -119681,9 +120002,9 @@ aZq
 dzl
 taY
 aFh
-biP
-bjP
-bkL
+kNu
+bvI
+bqY
 blL
 bnc
 boj
@@ -119870,20 +120191,20 @@ alP
 ali
 aiR
 aoE
-auf
-auf
+cWP
+cWP
 arj
 arj
 ata
 arj
-arj
-auf
-auf
+igK
+cWP
+cWP
 auf
 auf
 axr
 amW
-auf
+cWP
 cLu
 mvV
 cLG
@@ -119908,7 +120229,7 @@ aZq
 aVW
 ccK
 ccK
-ccr
+uet
 baT
 ccD
 aWW
@@ -119938,11 +120259,11 @@ aZq
 bgy
 bhs
 big
-biP
-biP
-biP
-biP
-biP
+kNu
+kNu
+kNu
+kNu
+kNu
 boi
 bBh
 bqU
@@ -120127,7 +120448,7 @@ aCw
 amN
 aiR
 aow
-auf
+cWP
 aqo
 arb
 auf
@@ -120136,7 +120457,7 @@ auf
 arb
 auf
 auf
-auf
+cWP
 auf
 axs
 amW
@@ -120172,12 +120493,12 @@ xXK
 xXK
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
 xXK
 xXK
-cXh
+biL
 xXK
 xXK
 xXK
@@ -120383,7 +120704,7 @@ ali
 alQ
 amO
 aiR
-auf
+cWP
 auf
 axs
 arc
@@ -120394,7 +120715,7 @@ avm
 axs
 auf
 auf
-aAd
+amD
 ati
 aCm
 auf
@@ -120420,8 +120741,8 @@ cYi
 aVs
 cMn
 aVY
-cYi
-cYi
+xzO
+xzO
 aWL
 aWT
 cIr
@@ -120430,10 +120751,10 @@ cIm
 cIm
 cIm
 cWp
-cIm
-cIm
-cIm
-cIm
+cWp
+cWp
+cWp
+cWp
 cWx
 cIm
 cIm
@@ -120451,7 +120772,7 @@ ohX
 ohX
 wTC
 taY
-bic
+byY
 biP
 bjO
 bkK
@@ -120662,7 +120983,7 @@ aIx
 aJw
 aKv
 aLu
-aQE
+leq
 aQE
 aBo
 aPM
@@ -120686,12 +121007,12 @@ cXX
 cXX
 cXX
 cXX
-ayw
+cXX
 cXX
 cYh
 cXX
 cXX
-cXX
+aoW
 cXX
 cXX
 cXX
@@ -120699,9 +121020,9 @@ cXX
 atJ
 dyZ
 bfm
-dyZ
-dyZ
-dyZ
+bTV
+bTV
+bTV
 dyZ
 djn
 dyZ
@@ -120720,9 +121041,9 @@ bqX
 bsD
 btU
 bAa
-bwO
-vgd
-oHu
+bAa
+bAa
+bAa
 bAa
 bBq
 eRI
@@ -120800,16 +121121,16 @@ csG
 csG
 csG
 cmf
-cup
-cup
+aOI
+aOI
 cmf
 csG
 csG
 csG
 csG
 cmf
-cup
-cup
+aOI
+aOI
 cmf
 aaa
 aaa
@@ -120919,7 +121240,7 @@ aQE
 avk
 asZ
 aLv
-aQE
+leq
 aQE
 aOk
 aPN
@@ -120933,7 +121254,7 @@ haY
 aVh
 aVt
 aVE
-haY
+cwE
 aWp
 haY
 haY
@@ -120973,16 +121294,16 @@ bij
 bij
 bij
 bpG
-bqY
-bxY
-btV
-iNd
-bwP
-bxW
-byY
-bvI
-dBd
-dBn
+bqX
+eRI
+btU
+bAa
+bAa
+bAa
+bAa
+bAa
+bBq
+eRI
 bDu
 dBc
 aaP
@@ -121200,12 +121521,12 @@ spn
 spn
 spn
 spn
-cXh
+biL
 spn
 spn
 spn
 spn
-cXh
+biL
 spn
 spn
 spn
@@ -121231,15 +121552,15 @@ bng
 bij
 bpH
 dAd
-dAn
-aDc
-aDc
+bxY
+btV
+aZu
 lBY
 sKX
-bxY
-aDc
-aDc
-dAn
+aIZ
+pjG
+dBd
+dBn
 bDv
 dBc
 aaP
@@ -121445,7 +121766,7 @@ aZO
 aZq
 aUP
 cYk
-jry
+gLi
 jry
 lqW
 aZq
@@ -121488,15 +121809,15 @@ bnh
 bij
 dzX
 bqZ
-bCi
-bCi
-bCi
-bCi
-btW
-byZ
-bCi
-bCi
-bCi
+dAn
+aDc
+aDc
+bxY
+aDc
+bxY
+aDc
+aDc
+dAn
 bDw
 dBc
 aaP
@@ -121696,13 +122017,13 @@ aQE
 asb
 aQF
 aoC
-aSn
+uHv
 any
 aZO
 aZq
 aUQ
 cYq
-bMB
+ujd
 dhQ
 aWa
 aZq
@@ -121745,15 +122066,15 @@ bni
 bol
 bpJ
 dAe
-bwI
-bBh
-bwI
-bBh
-aIZ
-bBh
-bBh
-bBs
-bBh
+bCi
+bCi
+bCi
+bCi
+bCi
+byZ
+bCi
+bCi
+bCi
 dBw
 dBc
 bpO
@@ -121953,7 +122274,7 @@ aQE
 aQE
 aIE
 aoC
-aSn
+uHv
 any
 aZO
 aZq
@@ -122007,7 +122328,7 @@ btX
 aIs
 aIs
 aIs
-bpM
+bBt
 bAb
 bBt
 bCp
@@ -122082,13 +122403,13 @@ aZO
 aiL
 aaa
 cmf
-cup
+aOI
 cmf
 aiL
 aiL
 aaa
 cmf
-cup
+aOI
 cmf
 aaa
 aaf
@@ -122265,7 +122586,7 @@ cKh
 xho
 qLi
 xho
-bpO
+dBc
 bBu
 trT
 lZg
@@ -122835,15 +123156,15 @@ czn
 cdT
 cfU
 cdT
-chj
+cfU
 cFM
 czn
 czn
 czn
 cdT
-chj
+cfU
 cFM
-chj
+cfU
 cdT
 cdT
 cdT
@@ -122967,11 +123288,11 @@ axs
 axs
 ati
 cCi
-aDH
-any
+nGt
+cWR
 aGB
-aIE
-aIy
+hFN
+jTv
 aJD
 any
 mOY
@@ -122979,7 +123300,7 @@ mOY
 mOY
 jut
 lfw
-nde
+ePn
 quL
 jut
 aWY
@@ -123224,7 +123545,7 @@ ayO
 aAi
 ati
 aCn
-aDH
+qET
 any
 aGC
 aJE
@@ -123236,7 +123557,7 @@ mOY
 jut
 fGf
 uLT
-pvh
+lHT
 sfj
 fJs
 jut
@@ -123468,7 +123789,7 @@ aiL
 aZO
 anx
 aoB
-auf
+cWP
 auf
 auf
 avu
@@ -123477,11 +123798,11 @@ auf
 auf
 auf
 auf
-auf
+cWP
 aAd
 ati
 aCs
-aDH
+qET
 aEZ
 aJE
 aHu
@@ -123725,12 +124046,12 @@ aZO
 aZO
 ati
 mJv
-auf
+cWP
 auf
 kFg
 eBK
-ata
-arj
+psF
+igK
 djz
 auf
 auf
@@ -124009,10 +124330,10 @@ mcn
 ojU
 mUm
 aWY
+ipy
 sfj
 sfj
-sfj
-lte
+ekz
 dZA
 avN
 eik
@@ -124118,7 +124439,7 @@ aaa
 aaa
 aaa
 cdT
-ckK
+chk
 cdT
 chk
 cdT
@@ -124774,7 +125095,7 @@ aGC
 aGC
 aGC
 aGC
-pvh
+lHT
 pvh
 pTI
 dsl
@@ -125279,7 +125600,7 @@ avp
 ayW
 avp
 ceH
-vkl
+rcp
 wlp
 lte
 lte
@@ -125287,7 +125608,7 @@ lte
 lte
 lte
 mUm
-sfj
+ipy
 aMt
 jut
 mOY

--- a/_maps/map_files/Cerestation/cerestation.dmm
+++ b/_maps/map_files/Cerestation/cerestation.dmm
@@ -3580,7 +3580,7 @@
 "aoW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "aoY" = (
 /obj/structure/dresser,
 /obj/structure/cable,
@@ -10943,8 +10943,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
 "aKu" = (
@@ -11298,7 +11296,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
 "aLq" = (
@@ -11619,7 +11616,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
 "aMn" = (
@@ -12001,7 +11997,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
 "aNs" = (
@@ -12021,7 +12016,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
 "aNt" = (
@@ -12273,7 +12267,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/starboard)
 "aOh" = (
@@ -23230,9 +23223,7 @@
 /turf/open/floor/plating,
 /area/commons/storage/primary)
 "brz" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/structure/barricade/wooden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -37098,9 +37089,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37986,7 +37974,6 @@
 /area/hallway/primary/aft)
 "cgd" = (
 /obj/machinery/door/airlock/external{
-	cyclelinkeddir = 1;
 	name = "Construction Zone";
 	req_access = null;
 	req_access_txt = "0";
@@ -39412,9 +39399,6 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "ckM" = (
 /obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -43187,7 +43171,6 @@
 "ctc" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/door/airlock/engineering{
-	cyclelinkeddir = 1;
 	name = "Auxillary Base Construction";
 	req_access_txt = "0";
 	req_one_access_txt = "32;47;48"
@@ -52151,9 +52134,7 @@
 /turf/open/floor/plating,
 /area/maintenance/external/port)
 "cTB" = (
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/structure/barricade/wooden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -52871,7 +52852,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "cWs" = (
 /obj/structure/chair/wood,
 /obj/structure/cable,
@@ -52899,7 +52880,7 @@
 	c_tag = "Medbay-Cargo Bridge"
 	},
 /turf/open/floor/engine,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "cWC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60661,6 +60642,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
+"eJh" = (
+/turf/open/floor/engine,
+/area/hallway/primary/starboard)
 "eJy" = (
 /obj/machinery/quantumpad,
 /turf/open/floor/iron/dark,
@@ -60951,7 +60935,7 @@
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/hallway/primary/central)
+/area/hallway/primary/starboard)
 "fHO" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -60992,6 +60976,9 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"fMD" = (
+/turf/closed/wall/r_wall,
+/area/hallway/primary/starboard)
 "fOI" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -61419,6 +61406,10 @@
 /obj/effect/baseturf_helper/asteroid,
 /turf/open/floor/iron/white,
 /area/science/lab)
+"gTv" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/engine,
+/area/hallway/primary/starboard)
 "gTA" = (
 /turf/closed/wall/rust,
 /area/commons/fitness)
@@ -62698,6 +62689,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
+"jEQ" = (
+/obj/structure/girder,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "jFA" = (
 /turf/closed/mineral/random/stationside/asteroid/porus,
 /area/maintenance)
@@ -63044,9 +63042,7 @@
 /area/maintenance/fore/greater)
 "kqC" = (
 /obj/structure/barricade/wooden,
-/obj/machinery/door/airlock/external/glass{
-	cyclelinkeddir = 8
-	},
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "krn" = (
@@ -63804,6 +63800,10 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/asteroid,
 /area/maintenance/department/engine)
+"mgg" = (
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/hallway/primary/starboard)
 "mhg" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -68113,6 +68113,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore/greater)
+"vAc" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "vAH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/baseturf_helper/asteroid,
@@ -69172,6 +69178,10 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/fore)
+"ybp" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/engine,
+/area/hallway/primary/starboard)
 "ybP" = (
 /turf/closed/mineral/random/low_chance,
 /area/maintenance/external/aft)
@@ -120489,20 +120499,20 @@ aZq
 aZq
 aZq
 aZq
-xXK
-xXK
-xXK
-xXK
-biL
-xXK
-xXK
-xXK
-xXK
-biL
-xXK
-xXK
-xXK
-xXK
+vAc
+vAc
+vAc
+vAc
+fMD
+vAc
+vAc
+vAc
+vAc
+fMD
+vAc
+vAc
+vAc
+vAc
 aZq
 aZq
 aZq
@@ -120746,20 +120756,20 @@ xzO
 aWL
 aWT
 cIr
-cIm
-cIm
-cIm
-cIm
+ybp
+ybp
+ybp
+ybp
 cWp
 cWp
 cWp
 cWp
 cWp
 cWx
-cIm
-cIm
-cIm
-cIm
+ybp
+ybp
+ybp
+ybp
 cIr
 ohX
 ohX
@@ -121003,20 +121013,20 @@ dyZ
 aWM
 dyZ
 atJ
-cXX
-cXX
-cXX
-cXX
-cXX
-cXX
-cYh
-cXX
-cXX
+eJh
+eJh
+eJh
+eJh
+eJh
+eJh
+gTv
+eJh
+eJh
 aoW
-cXX
-cXX
-cXX
-cXX
+eJh
+eJh
+eJh
+eJh
 atJ
 dyZ
 bfm
@@ -121260,20 +121270,20 @@ haY
 haY
 haY
 aZt
-ayw
-ayw
-ayw
-ayw
+mgg
+mgg
+mgg
+mgg
 fGU
-ayw
-ayw
-ayw
-ayw
+mgg
+mgg
+mgg
+mgg
 fGU
-ayw
-ayw
-ayw
-ayw
+mgg
+mgg
+mgg
+mgg
 aZt
 haY
 bas
@@ -121517,20 +121527,20 @@ aZq
 aZq
 aZq
 aZq
-spn
-spn
-spn
-spn
-biL
-spn
-spn
-spn
-spn
-biL
-spn
-spn
-spn
-spn
+jEQ
+jEQ
+jEQ
+jEQ
+fMD
+jEQ
+jEQ
+jEQ
+jEQ
+fMD
+jEQ
+jEQ
+jEQ
+jEQ
 aZq
 aZq
 aZq


### PR DESCRIPTION
Fixes concerning Cere Playtest Number 2 on Manuel.
All posted issues resolved
medbay minorly improved without compromising Cere design
cyclelinks fixed, doors should actually cycle
messed with areas slightly, no more space apcs
disposals bug due to flipped var resolved
removed duplicate/varedited APCs
powergen is still very difficult, should be somewhat resolved
